### PR TITLE
Decouple filtered methods detection and test instances initialization from suite executions.

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -254,11 +254,14 @@ module Minitest
 
     def self.run reporter, options = {}
       filtered_methods(options).each do |method_name|
-        result = self.new(method_name).run
+        result = init_runnable(method_name, options).run
         raise "#{self}#run _must_ return self" unless self === result
         reporter.record result
       end
     end
+
+    ##
+    # Responsible for detecting all runnable methods in a given class.
 
     def self.filtered_methods options = {}
       filter = options[:filter] || '/./'
@@ -267,6 +270,15 @@ module Minitest
       self.runnable_methods.find_all { |m|
         filter === m || filter === "#{self}##{m}"
       }
+    end
+
+    ##
+    # Responsible for initializing the runnable instances.
+    # This method receives the options hash to allow
+    # extensions to use them.
+
+    def self.init_runnable method_name, options = {}
+      self.new(method_name)
     end
 
     ##

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -253,18 +253,20 @@ module Minitest
     # reporter to record.
 
     def self.run reporter, options = {}
-      filter = options[:filter] || '/./'
-      filter = Regexp.new $1 if filter =~ /\/(.*)\//
-
-      filtered_methods = self.runnable_methods.find_all { |m|
-        filter === m || filter === "#{self}##{m}"
-      }
-
-      filtered_methods.each do |method_name|
+      filtered_methods(options).each do |method_name|
         result = self.new(method_name).run
         raise "#{self}#run _must_ return self" unless self === result
         reporter.record result
       end
+    end
+
+    def self.filtered_methods options = {}
+      filter = options[:filter] || '/./'
+      filter = Regexp.new $1 if filter =~ /\/(.*)\//
+
+      self.runnable_methods.find_all { |m|
+        filter === m || filter === "#{self}##{m}"
+      }
     end
 
     ##


### PR DESCRIPTION
The interface in Minitest 5 makes extending Runnable harder. The `run` method in the `Runnable` class has three responsibilities:

1. Detect methods to run.
2. Create test instances.
2. Run tests.

Moving the detection logic and the test instances initialization to separated methods makes it more easy to extend.