### PR TITLE
add `expect` method that returns an expectation proxy

### DIFF
--- a/lib/minitest/expectations.rb
+++ b/lib/minitest/expectations.rb
@@ -9,8 +9,9 @@
 #
 #     it "should still work in threads" do
 #       my_threaded_thingy do
-#         (1+1).must_equal 2  # bad
-#         assert_equal 2, 1+1 # good
+#         (1+1).must_equal 2         # bad
+#         assert_equal 2, 1+1        # good
+#         expect(1 + 1).must_equal 2 # good
 #       end
 #     end
 

--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -1,13 +1,6 @@
 require "minitest/test"
 
-class Minitest::Expectation # :nodoc:
-  attr_reader :target, :ctx
-
-  def initialize target, ctx
-    @target = target
-    @ctx    = ctx
-  end
-end
+Minitest::Expectation = Struct.new :target, :ctx # :nodoc:
 
 class Module # :nodoc:
   def infect_an_assertion meth, new_name, dont_flip = false # :nodoc:

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -442,6 +442,11 @@ describe Minitest::Spec do
     end
   end
 
+  it "can use expect" do
+    @assertion_count -= 3
+    expect(1 + 1).must_equal 2
+  end
+
   it "needs to verify throw" do
     @assertion_count += 2 # 2 extra tests
 


### PR DESCRIPTION
Add an `expect` method so that we don't have to rely on thread locals for the test instance.  If we deprecate the object monkey patches (as RSpec has done) than we can completely eliminate the thread locals.

Also, [as noted](https://github.com/seattlerb/minitest/blob/dfa67e4ce0f94ceab2e4751f05ed3a659019ee1b/lib/minitest/expectations.rb#L11-L14) you can't use the object monkey patches inside something that is threaded because of the thread local usage.  The `expect` method will allow people to continue to use the expectation syntax but do it in a different thread