### PR TITLE
Makes mocks debugger-friendly by exposing instance vars

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -18,6 +18,8 @@ module Minitest # :nodoc:
       respond_to_missing?
       send
       to_s
+      instance_variables
+      instance_eval
     )
 
     instance_methods.each do |m|


### PR DESCRIPTION
When debugging using byebug or a similar debugger, I’d like to be able to inspect the instance variables of a mock. Doing so makes it easy to see what the mock has been set to expect, etc.

This change restores the debugger’s ability to perform that inspection.