### PR TITLE
backtrace not cleaned in minitest bundled with ruby 2.1.2

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -740,14 +740,16 @@ module Minitest
   end
 
   class BacktraceFilter # :nodoc:
+    INTERNALS = /#{Regexp.quote File.dirname(__FILE__)}/o
+
     def filter bt
       return ["No backtrace"] unless bt
 
       return bt.dup if $DEBUG
 
-      new_bt = bt.take_while { |line| line !~ /lib\/minitest/ }
-      new_bt = bt.select     { |line| line !~ /lib\/minitest/ } if new_bt.empty?
-      new_bt = bt.dup                                           if new_bt.empty?
+      new_bt = bt.take_while { |line| line !~ INTERNALS }
+      new_bt = bt.select     { |line| line !~ INTERNALS } if new_bt.empty?
+      new_bt = bt.dup                                     if new_bt.empty?
 
       new_bt
     end


### PR DESCRIPTION
Hello,

In the minitest that is bundled with ruby 2.1.2, the backtrace cleaner doesn't seem to be doing its job because I get lines like the following in assertion failure backtraces. :cold_sweat: 

Thanks for your consideration. 

```
    /usr/lib/ruby/2.1.0/minitest/unit.rb:1265:in `run'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:940:in `block in _run_suite'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:933:in `map'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:933:in `_run_suite'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:914:in `block in _run_suites'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:914:in `map'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:914:in `_run_suites'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:884:in `_run_anything'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:1092:in `run_tests'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:1079:in `block in _run'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:1078:in `each'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:1078:in `_run'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:1066:in `run'
    /usr/lib/ruby/2.1.0/minitest/unit.rb:802:in `block in autorun'
```