### PR TITLE
Adding "remove_expectations" method to Minitest::Mock

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -77,6 +77,19 @@ module Minitest # :nodoc:
       self
     end
 
+    ##
+    # Removes all expectations from a method +name+.
+    #
+    #   @mock.expect(:meaning_of_life, 42)
+    #   @mock.meaning_of_life # => 42
+    #
+    #   @mock.remove_expectations(:meaning_of_life)
+    #   @mock.meaning_of_life # raises MockExpectationError
+
+    def remove_expectations(name)
+      @expected_calls.delete(name)
+    end
+
     def __call name, data # :nodoc:
       case data
       when Hash then

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -345,6 +345,26 @@ class TestMinitestMock < Minitest::Test
     mock.verify
   end
 
+  def test_remove_expectations_from_a_method
+    mock = Minitest::Mock.new
+    mock.expect(:foo, true)
+    assert mock.foo
+
+    mock.remove_expectations(:foo)
+    e = assert_raises(NoMethodError) { mock.foo }
+    exp = "unmocked method :foo, expected one of []"
+
+    assert_equal exp, e.message
+  end
+
+  def test_remove_expectations_from_a_method_doesnt_affect_other_expectations
+    mock = Minitest::Mock.new
+    mock.expect(:foo, true)
+    mock.expect(:bar, false)
+
+    mock.remove_expectations(:bar)
+    assert mock.foo
+  end
 end
 
 require "minitest/metametameta"


### PR DESCRIPTION
I've added a new method to remove all expectations on a specific method:

    @mock.expect(:meaning_of_life, 42)
    @mock.meaning_of_life # => 42

    @mock.remove_expectations(:meaning_of_life)
    @mock.meaning_of_life # raises MockExpectationError