### PR TITLE
Randomization stuff

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -64,7 +64,7 @@ module Minitest
       case self.test_order
       when :random, :parallel then
         max = methods.size
-        methods.sort.sort_by { rand max }
+        methods.sort_by { rand max }
       when :alpha, :sorted then
         methods.sort
       else

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -195,7 +195,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
     end
 
     expected = clean <<-EOM
-      E.
+      .E
 
       Finished in 0.00
 
@@ -242,7 +242,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
     setup_basic_tu
 
     expected = clean <<-EOM
-      F.
+      .F
 
       Finished in 0.00
 
@@ -376,7 +376,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
     end
 
     expected = clean <<-EOM
-      S.
+      .S
 
       Finished in 0.00
 
@@ -403,8 +403,8 @@ class TestMinitestRunner < MetaMetaMetaTestCase
     end
 
     expected = clean <<-EOM
-      #<Class:0xXXX>#test_skip = 0.00 s = S
       #<Class:0xXXX>#test_something = 0.00 s = .
+      #<Class:0xXXX>#test_skip = 0.00 s = S
 
       Finished in 0.00
 


### PR DESCRIPTION
Hi!

I was reading through minitest code and I found one place which didn't seem right: https://github.com/seattlerb/minitest/blob/master/lib/minitest/test.rb#L67. Why are we sorting the array before shuffling it? I thought that was not neccessary and removing it would save as some CPU cycles, so I removed it. Then the test suite start failing and reading through it I found this: https://github.com/seattlerb/minitest/blob/master/test/minitest/metametameta.rb#L86. I'd say the only reason both lines are there is to make the tests pass... so I've removed them if this PR.

Let me know whether all this make any sense.

Cheers!