### PR TITLE
Avoid eagerly starting threads.

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -19,8 +19,10 @@ module Minitest
   ##
   # Parallel test executor
 
-  mc.send :attr_accessor, :parallel_executor
-  self.parallel_executor = Parallel::Executor.new((ENV['N'] || 2).to_i)
+  mc.send :attr_writer, :parallel_executor
+  def self.parallel_executor
+    @parallel_executor ||= Parallel::Executor.new((ENV['N'] || 2).to_i)
+  end
 
   ##
   # Filter object for backtraces.


### PR DESCRIPTION
cc @camilo

## Problem

Commit 34760e3b268bc1bb4ac5fe1a44ef1ff0a2f9bd4d made it such that `require 'minitest'` starts 2 threads by default.

This can easily result in minitest threads running outside of the test environment (even in production).  For instance, activesupport has a [runtime dependancy on minitest](https://github.com/rails/rails/blob/v4.1.9/activesupport/activesupport.gemspec#L26), then using a gem like prototype-rails that [extends a test case class](https://github.com/rails/prototype-rails/blob/v4.0.0/lib/prototype-rails/on_load_action_view.rb#L17) will result in two minitest threads starting in any environment.

## Solution

Use a memoized accessor method to get the `Parallel::Executor` instance so that the threads are only started when there are tests to run.