### PR TITLE
Print command that runs a single test for each of the failed tests

### DIFF
--- a/test/minitest/metametameta.rb
+++ b/test/minitest/metametameta.rb
@@ -60,6 +60,7 @@ class MetaMetaMetaTestCase < Minitest::Test
     output.gsub!(/ = \d+.\d\d s = /, ' = 0.00 s = ')
     output.gsub!(/0x[A-Fa-f0-9]+/, '0xXXX')
     output.gsub!(/ +$/, '')
+    output.gsub!(/^ruby .*?.rb/, 'ruby FILE')
 
     if windows? then
       output.gsub!(/\[(?:[A-Za-z]:)?[^\]:]+:\d+\]/, '[FILE:LINE]')

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -223,6 +223,10 @@ class TestMinitestReporter < MetaMetaMetaTestCase
       boo
 
       1 runs, 0 assertions, 1 failures, 0 errors, 0 skips
+
+      # Failed tests:
+
+      ruby FILE -n 'Minitest::Test#woot'
     EOM
 
     assert_equal exp, normalize_output(io.string)
@@ -249,6 +253,10 @@ class TestMinitestReporter < MetaMetaMetaTestCase
           FILE:LINE:in `test_report_error'
 
       1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
+
+      # Failed tests:
+
+      ruby FILE -n 'Minitest::Test#woot'
     EOM
 
     assert_equal exp, normalize_output(io.string)

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -205,6 +205,10 @@ class TestMinitestRunner < MetaMetaMetaTestCase
           FILE:LINE:in \`test_error\'
 
       2 runs, 1 assertions, 0 failures, 1 errors, 0 skips
+
+      # Failed tests:
+
+      ruby FILE -n '#<Class:0xXXX>#test_error'
     EOM
 
     assert_report expected
@@ -233,6 +237,10 @@ class TestMinitestRunner < MetaMetaMetaTestCase
           FILE:LINE:in \`teardown\'
 
       1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
+
+      # Failed tests:
+
+      ruby FILE -n '#<Class:0xXXX>#test_something'
     EOM
 
     assert_report expected
@@ -251,6 +259,10 @@ class TestMinitestRunner < MetaMetaMetaTestCase
       Failed assertion, no message given.
 
       2 runs, 2 assertions, 1 failures, 0 errors, 0 skips
+
+      # Failed tests:
+
+      ruby FILE -n '#<Class:0xXXX>#test_failure'
     EOM
 
     assert_report expected


### PR DESCRIPTION
Make @tenderlove (and his cat) happier with the Minitest. :smiley_cat:

See section “Things I dislike about Minitest” of the blog post [My experience with Minitest and RSpec](http://tenderlovemaking.com/2015/01/23/my-experience-with-minitest-and-rspec.html).

Example:

```
...
285 runs, 841 assertions, 2 failures, 0 errors, 0 skips

# Failed tests:

ruby test/minitest/test_minitest_unit.rb -n 'TestMinitestRunner#test_run_error_teardown'
ruby test/minitest/test_minitest_reporter.rb -n 'TestMinitestReporter#test_start'
```