### PR TITLE
lazily start the parallel executor

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -123,6 +123,7 @@ module Minitest
     self.init_plugins options
     self.reporter = nil # runnables shouldn't depend on the reporter, ever
 
+    self.parallel_executor.start if parallel_executor.respond_to?(:start)
     reporter.start
     __run reporter, options
     self.parallel_executor.shutdown

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -17,6 +17,13 @@ module Minitest
       def initialize size
         @size  = size
         @queue = Queue.new
+        @pool  = nil
+      end
+
+      ##
+      # Start the executor
+
+      def start
         @pool  = size.times.map {
           Thread.new(@queue) do |queue|
             Thread.current.abort_on_exception = true


### PR DESCRIPTION
This has two benefits:

* Gives a hook for exetutors to start threads / processes
* Avoids booting threads when minitest is loaded but not in use