### PR TITLE
Readme cleanup

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -425,7 +425,6 @@ capybara_minitest_spec      :: Bridge between Capybara RSpec matchers and
                                page.must_have_content("Title")).
 minispec-metadata           :: Metadata for describe/it blocks
                                (e.g. `it "requires JS driver", js: true do`)
-minitest-ansi               :: Colorize minitest output with ANSI colors.
 minitest-around             :: Around block for minitest. An alternative to
                                setup/teardown dance.
 minitest-bang               :: Adds support for RSpec-style let! to immediately
@@ -437,8 +436,6 @@ minitest-capybara           :: Capybara matchers support for minitest unit and
                                spec.
 minitest-chef-handler       :: Run Minitest suites as Chef report handlers
 minitest-ci                 :: CI reporter plugin for Minitest.
-minitest-colorize           :: Colorize Minitest output and show failing tests
-                               instantly.
 minitest-context            :: Defines contexts for code reuse in Minitest
                                specs that share common expectations.
 minitest-debugger           :: Wraps assert so failed assertions drop into

--- a/README.txt
+++ b/README.txt
@@ -499,7 +499,6 @@ minitest-stub-const         :: Stub constants for the duration of a block.
 minitest-tags               :: Add tags for minitest.
 minitest-vcr                :: Automatic cassette managment with Minitest::Spec
                                and VCR.
-minitest-wscolor            :: Yet another test colorizer.
 minitest_owrapper           :: Get tests results as a TestResult object.
 minitest_should             :: Shoulda style syntax for minitest test::unit.
 minitest_tu_shim            :: Bridges between test/unit and minitest.


### PR DESCRIPTION
I'm finding several listed extensions which don't work with the current minitest version, and don't show signs of being fixed. I'm starting this Pull Request to clean these out.

**Removed entries:**

* [minitest-ansi](https://github.com/rizzatti/minitest-ansi/issues/1)
* [minitest-colorize](https://github.com/sobrinho/minitest-colorize)
* [minitest-wscolor](https://github.com/wsc/minitest-wscolor)