### PR TITLE
stop allocating time objects

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -507,7 +507,7 @@ module Minitest
     end
 
     def start # :nodoc:
-      self.start_time = Time.now
+      self.start_time = Minitest.clock_time
     end
 
     def record result # :nodoc:
@@ -521,7 +521,7 @@ module Minitest
       aggregate = results.group_by { |r| r.failure.class }
       aggregate.default = [] # dumb. group_by should provide this
 
-      self.total_time = Time.now - start_time
+      self.total_time = Minitest.clock_time - start_time
       self.failures   = aggregate[Assertion].size
       self.errors     = aggregate[UnexpectedError].size
       self.skips      = aggregate[Skip].size
@@ -779,6 +779,16 @@ module Minitest
     result = klass.new(method_name).run
     raise "#{klass}#run _must_ return self" unless klass === result
     result
+  end
+
+  if defined? Process::CLOCK_MONOTONIC
+    def self.clock_time
+      Process.clock_gettime Process::CLOCK_MONOTONIC
+    end
+  else
+    def self.clock_time
+      Time.now
+    end
   end
 end
 

--- a/lib/minitest/benchmark.rb
+++ b/lib/minitest/benchmark.rb
@@ -90,9 +90,9 @@ module Minitest
 
       range.each do |x|
         GC.start
-        t0 = Time.now
+        t0 = Minitest.clock_time
         instance_exec(x, &work)
-        t = Time.now - t0
+        t = Minitest.clock_time - t0
 
         io.print "\t%9.6f" % t
         times << t

--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -251,11 +251,11 @@ module Minitest
     end
 
     def time_it # :nodoc:
-      t0 = Time.now
+      t0 = Minitest.clock_time
 
       yield
     ensure
-      self.time = Time.now - t0
+      self.time = Minitest.clock_time - t0
     end
 
     def to_s # :nodoc:
@@ -267,10 +267,10 @@ module Minitest
     end
 
     def with_info_handler &block # :nodoc:
-      t0 = Time.now
+      t0 = Minitest.clock_time
 
       handler = lambda do
-        warn "\nCurrent: %s#%s %.2fs" % [self.class, self.name, Time.now - t0]
+        warn "\nCurrent: %s#%s %.2fs" % [self.class, self.name, Minitest.clock_time - t0]
       end
 
       self.class.on_signal "INFO", handler, &block


### PR DESCRIPTION
Instead of allocating time objects, we can use the monotonic clock (if
it is available).  This gives us the benefit of dropping allocations and
will avoid incorrect time reporting due to the system clock changing or
people stubbing Time.now and they forget to unstub (lol).

Here is the test I used:

```ruby
require 'minitest'
require 'allocation_tracer'

class AmericaTest < Minitest::Test
  def test_freedom
    assert true
  end
end

result = ObjectSpace::AllocationTracer.trace do
  3000.times do
    Minitest.run_one_method(AmericaTest, 'test_freedom')
  end
end

p ObjectSpace::AllocationTracer.allocated_count_table[:T_DATA]
```

Before this patch, each test would allocate 9 T_DATA objects per test.
After this patch, it allocates 6 T_DATA objects per test.