### PR TITLE
Failed examples

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -565,6 +565,7 @@ module Minitest
       io.puts statistics
       io.puts aggregated_results
       io.puts summary
+      io.puts failed_examples if failures > 0
     end
 
     def statistics # :nodoc:
@@ -596,6 +597,14 @@ module Minitest
 
       "%d runs, %d assertions, %d failures, %d errors, %d skips%s" %
         [count, assertions, failures, errors, skips, extra]
+    end
+
+    def failed_examples # :nodoc:
+      failed_tests = results.each.map { |result|
+        "ruby #{result.failure.location.split(":").first} -n #{result.class}##{result.name}"
+      }.join("\n")
+
+      "\nFailed examples:\n\n#{failed_tests}"
     end
   end
 

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -223,6 +223,10 @@ class TestMinitestReporter < MetaMetaMetaTestCase
       boo
 
       1 runs, 0 assertions, 1 failures, 0 errors, 0 skips
+
+      Failed examples:
+
+      ruby test/minitest/test_minitest_reporter.rb -n Minitest::Test#woot
     EOM
 
     assert_equal exp, normalize_output(io.string)

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -251,6 +251,10 @@ class TestMinitestRunner < MetaMetaMetaTestCase
       Failed assertion, no message given.
 
       2 runs, 2 assertions, 1 failures, 0 errors, 0 skips
+
+      Failed examples:
+
+      ruby test/minitest/test_minitest_unit.rb -n #<Class:0xXXX>#test_failure
     EOM
 
     assert_report expected


### PR DESCRIPTION
Changes SummaryReporter to output example failures for easier running of single test cases.
After reading [Aaron Patterson's article](http://tenderlovemaking.com/2015/01/23/my-experience-with-minitest-and-rspec.html) on Minitest and RSpec I thought this would be great to have and it was easy enough to implement.