### PR TITLE
Add minitest-rerun-options to list of extensions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -514,6 +514,8 @@ minitest-profile            :: List the 10 slowest tests in your suite.
 minitest-rails              :: Minitest integration for Rails 3.x.
 minitest-rails-capybara     :: Capybara integration for Minitest::Rails.
 minitest-reporters          :: Create customizable Minitest output formats.
+minitest-rerun-options      :: Outputs the command line options to rerun
+                               failing tests.
 minitest-rg                 :: Colored red/green output for Minitest.
 minitest-rspec_mocks        :: Use RSpec Mocks with Minitest.
 minitest-server             :: minitest-server provides a client/server setup 


### PR DESCRIPTION
Adds `minitest-rerun-options` to list of extensions. 

I initially did some searching and couldn't find what I was looking for. So I worked on this and then when I finished, I decided to browse some more and found that https://github.com/grosser/minitest-rerun and https://github.com/seattlerb/minitest-sprint already does something similar (*face palm*).

Anyways do you still think there's value in this extension? I like the option for rerunning all failed tests. Is this something I should add to `minitest-sprint`?