### PR TITLE
Add minitest-fail-fast to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -479,6 +479,7 @@ minitest-english            :: Semantically symmetric aliases for assertions and
                                expectations.
 minitest-excludes           :: Clean API for excluding certain tests you
                                don't want to run under certain conditions.
+minitest-fail-fast          :: Reimplements RSpec's "fail fast" feature
 minitest-filecontent        :: Support unit tests with expectation results in files.
                                Differing results will be stored again in files.
 minitest-filesystem         :: Adds assertion and expectation to help testing


### PR DESCRIPTION
It was mentioned/asked for during your talk at Railsconf about the fail-fast feature for rspec, and the implementation that was out there no longer worked with Minitest 5. So I hacked this together on the flight back home, I hope that solves the problems for who-ever wants this feature

Hence, I added it to the README.

Source code : https://github.com/teoljungberg/minitest-fail-fast