### PR TITLE
Fix usage of proc targets in expectations for assertions that don't take blocks

### DIFF
--- a/lib/minitest/expectations.rb
+++ b/lib/minitest/expectations.rb
@@ -121,7 +121,7 @@ module Minitest::Expectations
   #
   # :method: must_output
 
-  infect_an_assertion :assert_output, :must_output
+  infect_an_assertion :assert_output, :must_output, :block
 
   ##
   # See Minitest::Assertions#assert_raises
@@ -130,7 +130,7 @@ module Minitest::Expectations
   #
   # :method: must_raise
 
-  infect_an_assertion :assert_raises, :must_raise
+  infect_an_assertion :assert_raises, :must_raise, :block
 
   ##
   # See Minitest::Assertions#assert_respond_to
@@ -157,7 +157,7 @@ module Minitest::Expectations
   #
   # :method: must_be_silent
 
-  infect_an_assertion :assert_silent, :must_be_silent
+  infect_an_assertion :assert_silent, :must_be_silent, :block
 
   ##
   # See Minitest::Assertions#assert_throws
@@ -166,7 +166,7 @@ module Minitest::Expectations
   #
   # :method: must_throw
 
-  infect_an_assertion :assert_throws, :must_throw
+  infect_an_assertion :assert_throws, :must_throw, :block
 
   ##
   # See Minitest::Assertions#refute_empty

--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -2,8 +2,15 @@ require "minitest/test"
 
 class Module # :nodoc:
   def infect_an_assertion meth, new_name, dont_flip = false # :nodoc:
+    if dont_flip == :block
+      block = true
+      dont_flip = false
+    else
+      block = false
+    end
+
     # warn "%-22p -> %p %p" % [meth, new_name, dont_flip]
-    self.class_eval <<-EOM
+    self.class_eval <<-EOM, __FILE__, __LINE__ + 1
       def #{new_name} *args
         Minitest::Expectation.new(self, Minitest::Spec.current).#{new_name}(*args)
       end
@@ -14,7 +21,7 @@ class Module # :nodoc:
         case
         when #{!!dont_flip} then
           ctx.#{meth}(target, *args)
-        when Proc === target then
+        when #{block} && Proc === target then
           ctx.#{meth}(*args, &target)
         else
           ctx.#{meth}(args.first, target, *args[1..-1])

--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -2,12 +2,8 @@ require "minitest/test"
 
 class Module # :nodoc:
   def infect_an_assertion meth, new_name, dont_flip = false # :nodoc:
-    if dont_flip == :block
-      block = true
-      dont_flip = false
-    else
-      block = false
-    end
+    block = dont_flip == :block
+    dont_flip = false if block
 
     # warn "%-22p -> %p %p" % [meth, new_name, dont_flip]
     self.class_eval <<-EOM, __FILE__, __LINE__ + 1

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -15,7 +15,7 @@ describe Minitest::Spec do
   # do not parallelize this suite... it just can"t handle it.
 
   def assert_triggered expected = "blah", klass = Minitest::Assertion
-    @assertion_count += 2
+    @assertion_count += 1
 
     e = assert_raises(klass) do
       yield
@@ -24,7 +24,10 @@ describe Minitest::Spec do
     msg = e.message.sub(/(---Backtrace---).*/m, '\1')
     msg.gsub!(/\(oid=[-0-9]+\)/, "(oid=N)")
 
-    assert_equal expected, msg
+    if expected
+      @assertion_count += 1
+      assert_equal expected, msg
+    end
   end
 
   before do
@@ -182,6 +185,8 @@ describe Minitest::Spec do
   end
 
   it "needs to verify equality" do
+    @assertion_count += 1
+
     (6 * 7).must_equal(42).must_equal true
 
     assert_triggered "Expected: 42\n  Actual: 54" do
@@ -190,6 +195,10 @@ describe Minitest::Spec do
 
     assert_triggered "msg.\nExpected: 42\n  Actual: 54" do
       (6 * 9).must_equal 42, "msg"
+    end
+
+    assert_triggered nil do
+      proc{}.must_equal 42
     end
   end
 
@@ -282,7 +291,9 @@ describe Minitest::Spec do
   end
 
   it "needs to verify inequality" do
+    @assertion_count += 2
     42.wont_equal(6 * 9).must_equal false
+    proc{}.wont_equal(42).must_equal false
 
     assert_triggered "Expected 1 to not be equal to 1." do
       1.wont_equal 1
@@ -291,6 +302,7 @@ describe Minitest::Spec do
     assert_triggered "msg.\nExpected 1 to not be equal to 1." do
       1.wont_equal 1, "msg"
     end
+
   end
 
   it "needs to verify instances of a class" do
@@ -306,7 +318,10 @@ describe Minitest::Spec do
   end
 
   it "needs to verify kinds of a class" do
+    @assertion_count += 2
+
     42.wont_be_kind_of(String).must_equal false
+    proc{}.wont_be_kind_of(String).must_equal false
 
     assert_triggered "Expected 42 to not be a kind of Integer." do
       42.wont_be_kind_of Integer
@@ -318,7 +333,7 @@ describe Minitest::Spec do
   end
 
   it "needs to verify kinds of objects" do
-    @assertion_count += 2 # extra test
+    @assertion_count += 3 # extra test
 
     (6 * 7).must_be_kind_of(Fixnum).must_equal true
     (6 * 7).must_be_kind_of(Numeric).must_equal true
@@ -329,6 +344,10 @@ describe Minitest::Spec do
 
     assert_triggered "msg.\nExpected 42 to be a kind of String, not Fixnum." do
       (6 * 7).must_be_kind_of String, "msg"
+    end
+
+    assert_triggered nil do
+      proc{}.must_be_kind_of String
     end
   end
 

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -302,7 +302,6 @@ describe Minitest::Spec do
     assert_triggered "msg.\nExpected 1 to not be equal to 1." do
       1.wont_equal 1, "msg"
     end
-
   end
 
   it "needs to verify instances of a class" do


### PR DESCRIPTION
Previously, an expectation like this would raise an ArgumentError

  proc{}.wont_equal nil

Only expectations for assertions that explicitly use pass blocks
should treat proc targets specially.  In all other cases, the proc
target should be treated as a regular argument.

While here, use __FILE__ and __LINE__ + 1 on the class_eval for
better backtraces.