### PR TITLE
Make assert_raises respect subclasses

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -298,11 +298,7 @@ module Minitest
         raise e
       rescue Exception => e
         expected = exp.any? { |ex|
-          if ex.instance_of? Module then
-            e.kind_of? ex
-          else
-            e.instance_of? ex
-          end
+          e.kind_of? ex
         }
 
         assert expected, proc {

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -1236,26 +1236,10 @@ class TestMinitestUnitTestCase < Minitest::Test
     assert_equal expected, e.message
   end
 
-  def test_assert_raises_triggered_subclass
-    e = assert_raises Minitest::Assertion do
-      @tc.assert_raises StandardError do
-        raise AnError
-      end
+  def test_assert_raises_subclass
+    @tc.assert_raises StandardError do
+      raise AnError
     end
-
-    expected = clean <<-EOM.chomp
-      [StandardError] exception expected, not
-      Class: <AnError>
-      Message: <\"AnError\">
-      ---Backtrace---
-      FILE:LINE:in \`test_assert_raises_triggered_subclass\'
-      ---------------
-    EOM
-
-    actual = e.message.gsub(/^.+:\d+/, "FILE:LINE")
-    actual.gsub!(/block \(\d+ levels\) in /, "") if RUBY_VERSION >= "1.9.0"
-
-    assert_equal expected, actual
   end
 
   def test_assert_respond_to


### PR DESCRIPTION
Having assert_raises not respect subclasses leads to fragile specs,
where you cannot change your code to raise a subclass of an
existing exception class without breaking your specs.

assert_raises should operate similar to a rescue block.  If you do

```ruby
  assert_raises StandardError do
    raise RuntimeError
  end
```

that should not raise an assertion error, because RuntimeError is
a subclass of StandardError and if you do:

```ruby
  begin
    raise RuntimeError
  rescue StandardError
  end
```

the RuntimeError will be rescued.

This breaks backward compatibility, but IMO is the correct
behavior.  If you truly want to check for a specific exception
class:

```ruby
  e = assert_raises StandardError do
    raise RuntimeError
  end
  assert_instance_of e, StandardError
```