### PR TITLE
Make assert_raises with no arguments assume StandardError

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -290,6 +290,7 @@ module Minitest
 
     def assert_raises *exp
       msg = "#{exp.pop}.\n" if String === exp.last
+      exp = [StandardError] if exp.empty?
 
       begin
         yield

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -1141,6 +1141,12 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_raises_no_arguments
+    @tc.assert_raises do
+      raise StandardError, "blah"
+    end
+  end
+
   def test_assert_raises_module
     @tc.assert_raises MyModule do
       raise AnError


### PR DESCRIPTION
This reflects ruby's behavior, where rescue with no exception
classes assumes StandardError.