### PR TITLE
Add class method to the overriden methods list

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -12,6 +12,7 @@ module Minitest # :nodoc:
 
     overridden_methods = %w[
       ===
+      class
       inspect
       instance_eval
       instance_variables


### PR DESCRIPTION
Maybe there is some reason not to override this, but I found it useful when running some memory allocation benchmarks.