### PR TITLE
Inline verification error messages

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -140,7 +140,8 @@ module Minitest # :nodoc:
           [sym, expected_args.size, args.size]
       end
 
-      fully_matched = expected_args.zip(args).all? { |mod, a|
+      zipped_args = expected_args.zip(args)
+      fully_matched = zipped_args.all? { |mod, a|
         mod === a or mod == a
       }
 
@@ -151,7 +152,7 @@ module Minitest # :nodoc:
 
       @actual_calls[sym] << {
         :retval => retval,
-        :args => expected_args.zip(args).map { |mod, a| mod === a ? mod : a },
+        :args => zipped_args.map! { |mod, a| mod === a ? mod : a },
       }
 
       retval

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -97,6 +97,7 @@ module Minitest # :nodoc:
       @expected_calls.each do |name, calls|
         calls.each do |expected|
           raise MockExpectationError, "expected #{__call name, expected}, got [#{__call name, @actual_calls[name]}]" if
+            @actual_calls.key?(name) and
             not @actual_calls[name].include?(expected)
 
           raise MockExpectationError, "expected #{__call name, expected}" unless

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -97,7 +97,6 @@ module Minitest # :nodoc:
       @expected_calls.each do |name, calls|
         calls.each do |expected|
           raise MockExpectationError, "expected #{__call name, expected}, got [#{__call name, @actual_calls[name]}]" if
-            @actual_calls.key?(name) and
             not @actual_calls[name].include?(expected)
 
           raise MockExpectationError, "expected #{__call name, expected}" unless

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -96,14 +96,11 @@ module Minitest # :nodoc:
     def verify
       @expected_calls.each do |name, calls|
         calls.each do |expected|
-          msg1 = "expected #{__call name, expected}"
-          msg2 = "#{msg1}, got [#{__call name, @actual_calls[name]}]"
-
-          raise MockExpectationError, msg2 if
+          raise MockExpectationError, "expected #{__call name, expected}, got [#{__call name, @actual_calls[name]}]" if
             @actual_calls.key?(name) and
             not @actual_calls[name].include?(expected)
 
-          raise MockExpectationError, msg1 unless
+          raise MockExpectationError, "expected #{__call name, expected}" unless
             @actual_calls.key?(name) and
             @actual_calls[name].include?(expected)
         end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -19,7 +19,7 @@ class TestMinitestMock < Minitest::Test
   def test_blow_up_if_not_called
     @mock.foo
 
-    util_verify_bad "expected meaning_of_life() => 42, got []"
+    util_verify_bad "expected meaning_of_life() => 42"
   end
 
   def test_not_blow_up_if_everything_called
@@ -39,7 +39,7 @@ class TestMinitestMock < Minitest::Test
     @mock.meaning_of_life
     @mock.expect(:bar, true)
 
-    util_verify_bad "expected bar() => true, got []"
+    util_verify_bad "expected bar() => true"
   end
 
   def test_blow_up_on_wrong_number_of_arguments


### PR DESCRIPTION
By inlining verification error messages, we reduce the number of strings that need to be allocated
for successful cases.

We can also reduce the number of intermediate arrays that are created.

Running a simple benchmark on my machine got the performance from
37785.9 i/s to 44400.8 i/s, approximately.

Here's the benchmark if you want to test it:

```ruby
$LOAD_PATH.unshift '../lib'
require 'benchmark/ips'
require 'minitest'
require 'minitest/spec'
require 'minitest/mock'

reporter = Minitest::Reporter.new($stdout)
run_time = 30
warmup_time = 2

class Simple
  def str_size(str)
    str.size
  end
end

Benchmark.ips do |bench|
  bench.config(time: run_time, warmup: warmup_time)

  bench.report("Simple mock with minitest") do
    class MinitestTest < Minitest::Test
      def test_simple_mock
        instance = Simple.new
        str = Minitest::Mock.new
        str.expect(:size, nil, [])

        instance.str_size(str)

        str.verify
      end
    end

    Minitest::Test.run_one_method MinitestTest, :test_simple_mock, reporter
  end
end
```