### PR TITLE
Add support for shared descriptions

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -196,6 +196,84 @@ class Minitest::Spec < Minitest::Test
     end
 
     ##
+    # An array of arguments and blocks to pass to describe for classes that
+    # include the current module.
+
+    def shared_descriptions
+      @shared_descriptions ||= []
+    end
+
+    ##
+    # Add a describe block that will be shared by all classes including the current module.
+    # Example:
+    #
+    #   module EmptyBehavior
+    #     extend Minitest::Spec::DSL
+    #     shared_description "empty" do
+    #       before do
+    #         @that = double
+    #       end
+    #
+    #       it "must be empty?" do
+    #         @that.must_be :empty?
+    #       end
+    #
+    #       it "must have size equal to 0" do
+    #         @that.size.must_equal 0
+    #       end
+    #     end
+    #   end
+    #
+    #   describe "array" do
+    #     def double; @this + @this end
+    #
+    #     before do
+    #       @this = []
+    #     end
+    #
+    #     include EmptyBehavior
+    #   end
+    #
+    #   describe "hash" do
+    #     def double; @this.merge(@this) end
+    #
+    #     before do
+    #       @this = {}
+    #     end
+    #
+    #     include EmptyBehavior
+    #   end
+
+    def shared_description *desc, &block
+      raise TypeError, "can only call shared_description in a module, not a class" if is_a?(Class)
+      shared_descriptions << [desc, block]
+    end
+
+    ##
+    # For each of the modules given, if the included module has any shared descriptions
+    # and this is a class, call describe with all of the shared descriptions in the module.
+    # If the included module has any shared descriptions and this is a module,
+    # include the include module's shared descriptions in the current module's shared
+    # descriptions, so that classes that include the current module get the shared descriptions
+    # in the included modules.
+
+    def include(*mods)
+      res = super
+      mods.each do |mod|
+        if mod.respond_to?(:shared_descriptions)
+          if is_a?(Class)
+            mod.shared_descriptions.each do |args, block|
+              describe(*args, &block)
+            end
+          else
+            shared_descriptions.concat(mod.shared_descriptions).uniq!
+          end
+        end
+      end
+      res
+    end
+
+    ##
     # Define an expectation with name +desc+. Name gets morphed to a
     # proper test method name. For some freakish reason, people who
     # write specs don't like class inheritance, so this goes way out of

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -821,6 +821,47 @@ class TestMeta < MetaMetaMetaTestCase
     assert_equal %w[test_0001_inner-it], z.instance_methods(false).map(&:to_s)
   end
 
+  def test_shared_description
+    runnables = self.class.runnables.dup
+    runs = []
+    x = Module.new do
+      extend Minitest::Spec::DSL
+      shared_description "x" do
+        before{@order << :bx}
+        after{@order << :ax}
+        it("x"){@order << :x}
+      end
+    end
+
+    y = Module.new do
+      extend Minitest::Spec::DSL
+      include x
+      shared_description "y" do
+        include x
+        before{@order << :by}
+        after{@order << :ay}
+        it("y"){@order << :y}
+      end
+    end
+
+    z = describe "z" do
+      before{(@order = []) << :bz}
+      after{@order << :az; runs << [self.class.name, @order]}
+      it("z"){@order << :z}
+      include y
+    end
+
+    new_runnables = self.class.runnables.dup - runnables
+    assert_equal %w'z z::x z::y z::y::x', new_runnables.map(&:name).sort
+
+    new_runnables.each do |runnable|
+      runnable.runnable_methods.each do |method_name|
+        Minitest.run_one_method(runnable, method_name)
+      end
+    end
+    assert_equal [["z", [:bz, :z, :az]], ["z::x", [:bz, :bx, :x, :ax, :az]], ["z::y", [:bz, :by, :y, :ay, :az]], ["z::y::x", [:bz, :by, :bx, :x, :ax, :ay, :az]]], runs.sort
+  end
+
   def test_setup_teardown_behavior
     _, _, z, before_list, after_list = util_structure
 


### PR DESCRIPTION
Shared descriptions can be used inside modules that are included
in spec classes.  Usage of modules to share specs is currently
limited to sharing individual specs, shared descriptions allow
you to share spec subclasses across multiple specs.

Currently, if you want to share spec subclasses across multiple
specs, you end up having to do something ugly like:

```ruby
module SharedSpecSubclass
  def self.included(mod)
    super
    pr = proc do
      describe "some description" do
        before do
          # setup
        end

        it "should do something" do end
      end
    end
    if mod.is_a?(Class)
      mod.class_eval(&pr)
    else
      mod.extend(Module.new do
        define_method(:included) do |m|
          super(m)
          m.class_eval(&pr)
        end
      end)
    end
  end
end
```

This commit reduces the above case to:

```ruby
module SharedSpecSubclass
  extend Minitest::Spec::DSL
  shared_description "some description" do
    before do
      # setup
    end

    it "should do something" do end
  end
end
```

The example above is not an artificial example, it is taken
directly from Sequel's specs (which I'm converting from rspec to
minitest/spec).

Keeping with minitest's general approach of "It's Just Ruby",
there is no magic here.  We just save the shared_description
arguments and blocks in an array, and when the class includes
the module with the shared descriptions, we call describe at
that point with the arguments and block.

This supports not only classes including modules with shared
descriptions, but also classes including modules that include
modules with shared descriptions (which Sequel also uses).

Note that this code does not work if you do:

```ruby
  class Module
    include Minitest::Spec::DSL
  end
```

This is because Minitest::Spec::DSL#include will never be called
in this case.  In ruby 2.0+, you can use prepend instead of
include, but I don't think there is a workaround for ruby <2.0.

I'm not tied to this particular API, it was just the simplest
thing I could think of.  I'm fine with an alternative API that
lets you share spec subclasses.