### PR TITLE
Option to not shuffle suites

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -13,8 +13,11 @@ module Minitest
   @@installed_at_exit ||= false
   @@after_run = []
   @extensions = []
+  @should_shuffle_suites = true
 
   mc = (class << self; self; end)
+
+  mc.send :attr_accessor, :should_shuffle_suites
 
   ##
   # Parallel test executor
@@ -144,7 +147,7 @@ module Minitest
   # loaded if a Runnable calls parallelize_me!.
 
   def self.__run reporter, options
-    suites = Runnable.runnables.shuffle
+    suites = should_shuffle_suites ? Runnable.runnables.shuffle : Runnable.runnables
     parallel, serial = suites.partition { |s| s.test_order == :parallel }
 
     # If we run the parallel tests before the serial tests, the parallel tests


### PR DESCRIPTION
RATIONALE: http://stackoverflow.com/questions/30558791/minitest-i-suck-and-my-tests-are-order-dependent

USAGE:
`Minitest.should_shuffle_suites = false` to disable shuffling of suites.

