### PR TITLE
Return early if there are no filtered methods

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -289,6 +289,8 @@ module Minitest
         filter === m || filter === "#{self}##{m}"
       }
 
+      return if filtered_methods.empty?
+
       with_info_handler reporter do
         filtered_methods.each do |method_name|
           run_one_method self, method_name, reporter


### PR DESCRIPTION
This avoids setting up INFO signal handlers for every spec class,
even if there are no methods that will be run inside it.

Additionally, for runnables that override with_info_handler, to
record the number of suites or run code before/after/around suites,
this avoids running other unnecessary code.