### PR TITLE
Don't extend io with pride if io is not a tty

### DIFF
--- a/lib/minitest/pride_plugin.rb
+++ b/lib/minitest/pride_plugin.rb
@@ -13,7 +13,7 @@ module Minitest
       io    = klass.new options[:io]
 
       self.reporter.reporters.grep(Minitest::Reporter).each do |rep|
-        rep.io = io
+        rep.io = io if rep.io.tty?
       end
     end
   end


### PR DESCRIPTION
Otherwise running a test from TextMate or something else not understanding ANSI codes makes output much less readable.