### PR TITLE
add summary message for case that minitest is used from rake task

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -593,7 +593,7 @@ module Minitest
     def summary # :nodoc:
       extra = ""
 
-      extra = "\n\nYou have skipped tests. Run with --verbose for details." if
+      extra = "\n\nYou have skipped tests. Run with --verbose for details, or run with TESTOPTS='-v' if you are using rake." if
         results.any?(&:skipped?) unless options[:verbose] or ENV["MT_NO_SKIP_MSG"]
 
       "%d runs, %d assertions, %d failures, %d errors, %d skips%s" %


### PR DESCRIPTION
Right now, `SummaryReporter #summary` returns a message of `"You have skipped tests. Run with --verbose for details."` when you have skipped tests and you do not have option `--verbose`.

However, if you use rake and access `minitest` through the rake task, you cannot add option `--verbose` to rake command. Instead, you need add `TESTOPTS="-v" ` as an option to run in verbose mode. (http://docs.seattlerb.org/rake/Rake/TestTask.html)

Specifically, when I used minitest by `rake test` for `rails/activesupport` (as you can see below), I got the message `"You have skipped tests. Run with --verbose for details."` but it did not work when I added `--verbose` to the rake command. (The same thing was reported here https://github.com/rails/rails/issues/13641) I thought the message might be a bit confusing when you use `rake`.


```
$ bundle exec rake test                      [/rails/activesupport]
/Users/onoshunsuke/.rbenv/versions/2.2.2/bin/ruby -w -I"lib:test" -I"/Users/onoshunsuke/.rbenv/versions/2.2.2/lib/ruby/2.2.0" "/Users/onoshunsuke/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/*_test.rb"
I, [2015-07-11T14:54:41.023598 #94941]  INFO -- : localhost:11211 failed (count: 0) Errno::ECONNREFUSED: Connection refused - connect(2) for "localhost" port 11211
Skipping memcached tests. Start memcached and try again.
Run options: --seed 22404

# Running:

...............................................................................................................................................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................SSS

Finished in 9.057228s, 355.6276 runs/s, 42078.1060 assertions/s.

3221 runs, 381111 assertions, 0 failures, 0 errors, 158 skips

You have skipped tests. Run with --verbose for details.
```


I know it is definitely not a problem of `minitest`, but I guess it would be more helpful if you add an explanation of `run with TESTOPTS='-v' if you are using rake` just in case that user is using `minitest` through `rake` (which is maybe kind of common) :)