### PR TITLE
Bug in Mock#verify

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -65,8 +65,7 @@ module Minitest # :nodoc:
     #   @mock.verify  # => true
     #
     #   @mock.expect(:uses_one_string, true, ["foo"])
-    #   @mock.uses_one_string("bar") # => true
-    #   @mock.verify  # => raises MockExpectationError
+    #   @mock.uses_one_string("bar") # => raises MockExpectationError
 
     def expect(name, retval, args = [], &blk)
       name = name.to_sym

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -96,16 +96,11 @@ module Minitest # :nodoc:
     # expected.
 
     def verify
-      @expected_calls.each do |name, calls|
-        calls.each do |expected|
-          raise MockExpectationError, "expected #{__call name, expected}, got [#{__call name, @actual_calls[name]}]" if
-            @actual_calls.key?(name) and
-            not @actual_calls[name].include?(expected)
-
-          raise MockExpectationError, "expected #{__call name, expected}" unless
-            @actual_calls.key?(name) and
-            @actual_calls[name].include?(expected)
-        end
+      @expected_calls.each do |name, expected|
+        actual = @actual_calls.fetch(name, nil)
+        raise MockExpectationError, "expected #{__call name, expected[0]}" unless actual
+        raise MockExpectationError, "expected #{__call name, expected[actual.size]}, got [#{__call name, actual}]" if
+          actual.size < expected.size
       end
       true
     end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -240,6 +240,20 @@ class TestMinitestMock < Minitest::Test
     assert_equal exp, e.message
   end
 
+  def test_same_method_expects_with_same_args_blow_up_when_not_all_called
+    mock = Minitest::Mock.new
+    mock.expect :foo, nil, [:bar]
+    mock.expect :foo, nil, [:bar]
+
+    mock.foo :bar
+
+    e = assert_raises(MockExpectationError) { mock.verify }
+
+    exp = "expected foo(:bar) => nil, got [foo(:bar) => nil]"
+
+    assert_equal exp, e.message
+  end
+
   def test_verify_passes_when_mock_block_returns_true
     mock = Minitest::Mock.new
     mock.expect :foo, nil do


### PR DESCRIPTION
I noticed a bug in `Mock#verify`:

```ruby
mock = Minitest::Mock.new
mock.expect :foo, nil, [:bar]
mock.expect :foo, nil, [:bar]
mock.foo :bar
mock.verify
```

doesn't raise a `MockExpectationError`. Here's a fix consisting of the following commits:

* **add failing test for bug** - the test specifies an error message which is not optimal, but matches the current implementation (see below)
* **fix bug**
* **specify better error messages in tests** - improved the expected error messages (at least in my eyes) - _this has an effect on an existing test!_
* **fix tests** - since the history of actual calls isn't needed anymore for the new error messages, some code could be removed
* **fix method rdoc of expect** - the documentation didn't describe the current behavior