### PR TITLE
Change refute default message to include object

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -500,7 +500,7 @@ module Minitest
     # Fails if +test+ is truthy.
 
     def refute test, msg = nil
-      msg ||= "Failed refutation, no message given"
+      msg ||= "Expected #{mu_pp(test)} to not be truthy"
       not assert !test, msg
     end
 

--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -500,7 +500,7 @@ module Minitest
     # Fails if +test+ is truthy.
 
     def refute test, msg = nil
-      msg ||= "Expected #{mu_pp(test)} to not be truthy"
+      msg ||= message{ "Expected #{mu_pp(test)} to not be truthy" }
       not assert !test, msg
     end
 


### PR DESCRIPTION
I run accross this when any result signals an error. ie.

> refute flash.now[:alert]
> Failed refutation, no message given # but what was the error?

instead of

> refute flash.now[:alert], flash.now[:alert]
> Error in blah blah... # now I know my problem

I don't think it makes sense for assert because 'Expected nil to be
truthy' is not helpful