### PR TITLE
js - make it possible to dynamically adjust the order of tests within a run

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -292,7 +292,7 @@ module Minitest
       return if filtered_methods.empty?
 
       with_info_handler reporter do
-        filtered_methods.each do |method_name|
+        method_stream(filtered_methods) do |method_name|
           run_one_method self, method_name, reporter
         end
       end
@@ -306,6 +306,10 @@ module Minitest
 
     def self.run_one_method klass, method_name, reporter
       reporter.record Minitest.run_one_method(klass, method_name)
+    end
+
+    def self.method_stream(methods)
+      methods.each {|m| yield m}
     end
 
     def self.with_info_handler reporter, &block # :nodoc:


### PR DESCRIPTION
This PR makes it possible to make a scheduling decision about which test to run next at runtime.

At my company we run a lot of high level tests (particularly selenium tests) using Minitest as the underlying framework. Tests at such a high level tend to flake a lot more then simple unit tests. Transient network errors, some JS being a little slow, a browser having a cold cache and many more things outside of the programmers control can happen.
We talked to other companies and this is a common problem. Even after addressing as many sources of flakiness as possible and making the individual tests very resilient (extra waiting, retrying, etc) everyone seems to still have the occasional flake. Multiple people across companies have gravitated to the solution of just rerunning a test that failed up to twice more. If the test passes a subsequent run it does not count as failed. We have had our own patches to Minitest for years accomplishing this and I recently rewrote all of that when upgrading to Minitest 5. We thought (since it is a common problem) it would be great if Minitest had some support for making scheduling decisions for tests at runtime. This scheduler can be combined with a reporter to rerun a failed test and report it as passing or failing depending on the result of this rerun.

Currently supported scheduling strategies like :random or :parallel can be expressed in these terms too, but would require some more changes than what I did in this PR. I tried to stay backwards compatible and minimally invasive. My solution is such only a suggestion or starting point for discussion if you will.