### PR TITLE
Assert match only counts as one assertion

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -222,7 +222,7 @@ module Minitest
 
     def assert_match matcher, obj, msg = nil
       msg = message(msg) { "Expected #{mu_pp matcher} to match #{mu_pp obj}" }
-      assert_respond_to matcher, :"=~"
+      raise Minitest::Assertion, "Expected #{mu_pp(matcher)} (#{matcher.class}) to respond to =~" unless matcher.respond_to? :"=~"
       matcher = Regexp.new Regexp.escape matcher if String === matcher
       assert matcher =~ obj, msg
     end

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -33,7 +33,6 @@ describe Minitest::Spec do
       when String then
         assert_equal expected, msg
       when Regexp then
-        @assertion_count += 1
         assert_match expected, msg
       else
         flunk "Unknown: #{expected.inspect}"
@@ -459,8 +458,6 @@ describe Minitest::Spec do
   end
 
   it "needs to verify regexp matches" do
-    @assertion_count += 3 # must_match is 2 assertions
-
     "blah".must_match(/\w+/).must_equal true
 
     assert_triggered "Expected /\\d+/ to match \"blah\"." do

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -995,12 +995,12 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_match
-    @assertion_count = 2
+    @assertion_count = 1
     @tc.assert_match(/\w+/, "blah blah blah")
   end
 
   def test_assert_match_matcher_object
-    @assertion_count = 2
+    @assertion_count = 1
 
     pattern = Object.new
     def pattern.=~(_) true end
@@ -1009,7 +1009,7 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_match_matchee_to_str
-    @assertion_count = 2
+    @assertion_count = 1
 
     obj = Object.new
     def obj.to_str; "blah" end
@@ -1018,7 +1018,7 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_match_object_triggered
-    @assertion_count = 2
+    @assertion_count = 1
 
     pattern = Object.new
     def pattern.=~(_) false end
@@ -1030,7 +1030,7 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_match_triggered
-    @assertion_count = 2
+    @assertion_count = 1
     util_assert_triggered 'Expected /\d+/ to match "blah blah blah".' do
       @tc.assert_match(/\d+/, "blah blah blah")
     end
@@ -1073,7 +1073,7 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_output_both_regexps
-    @assertion_count = 4
+    @assertion_count = 2
 
     @tc.assert_output(/y.y/, /bl.h/) do
       print "yay"


### PR DESCRIPTION
Why:

* The method `assert_match` was counting as two assertions, for some
reason I could not figure out from the git log.

This change addresses the need by:

* Removing one of the assertions
* Still raising an asserting error with the expected message when the
matcher does not respond to the `=~` method, even though there is no
test for that, and I don't really understand why that would be needed.
A method like `assert_output` cleary states in the documentation it will
make two assertions. The `assert_match` method does not, on the
contrary, it claims to make one.

Fixes #584.