### PR TITLE
Adds option to verify the number of times a call is made

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -68,15 +68,15 @@ module Minitest # :nodoc:
     #   @mock.uses_one_string("bar") # => true
     #   @mock.verify  # => raises MockExpectationError
 
-    def expect(name, retval, args = [], times: nil, &blk)
+    def expect(name, retval, args = [], opts = {}, &blk)
       name = name.to_sym
 
       if block_given?
         raise ArgumentError, "args ignored when block given" unless args.empty?
-        @expected_calls[name] << { :retval => retval, :times => times, :block => blk }
+        @expected_calls[name] << { :retval => retval, :times => opts[:times], :block => blk }
       else
         raise ArgumentError, "args must be an array" unless Array === args
-        @expected_calls[name] << { :retval => retval, :times => times, :args => args }
+        @expected_calls[name] << { :retval => retval, :times => opts[:times], :args => args }
       end
       self
     end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -227,17 +227,13 @@ class TestMinitestMock < Minitest::Test
   end
 
   def test_same_method_expects_blow_up_when_not_all_called
-    mock = Minitest::Mock.new
-    mock.expect :foo, nil, [:bar]
-    mock.expect :foo, nil, [:baz]
+    @mock = Minitest::Mock.new
+    @mock.expect :foo, nil, [:bar]
+    @mock.expect :foo, nil, [:baz]
 
-    mock.foo :bar
+    @mock.foo :bar
 
-    e = assert_raises(MockExpectationError) { mock.verify }
-
-    exp = "expected foo(:baz) => nil, got [foo(:bar) => nil]"
-
-    assert_equal exp, e.message
+    util_verify_bad "expected foo(:baz) => nil, got [foo(:bar) => nil]"
   end
 
   def test_verify_passes_when_mock_block_returns_true
@@ -341,6 +337,30 @@ class TestMinitestMock < Minitest::Test
 
     mock.send(:foo, 1, 2, 3)
     mock.verify
+  end
+
+  def test_mock_was_called_x_times
+    mock = Minitest::Mock.new
+    mock.expect(:foo, true, [], times: 2)
+
+    mock.foo
+    mock.foo
+    mock.verify
+  end
+
+  def test_mock_was_never_called
+    mock = Minitest::Mock.new
+    mock.expect(:foo, true, [], times: 0)
+
+    mock.verify
+  end
+
+  def test_mock_blow_up_when_called_less_times
+    @mock = Minitest::Mock.new
+    @mock.expect(:foo, true, [], times: 2)
+
+    @mock.foo
+    util_verify_bad "expected foo() => true to be called 2 times but was called 1 times"
   end
 
 end


### PR DESCRIPTION
Why:

* It seems useful to be able to do this, especially in the situation
where you want to verify a method is never called, because that wasn't
even possible

This change addresses the need by:

* Storing the expected times with the expected call
* Making sure method_missing allows the call to go through when we
expect it more than once, even though we have only one record on the
expected_calls array, while also making sure it will fail if we aren't
expecting it more than once
* Doing most of the work on verify, to provide a nice error when the
number of times we expect a method to be called is not met. This is
opt-in, if you do not add a times option, the verify method won't even
touch this new code

As discussed in #566.