### PR TITLE
Made a special exception handling for multiple stubs

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -200,7 +200,7 @@ class Object
     new_name = "__minitest_stub__#{name}"
 
     if respond_to? new_name
-      raise StubError, "method :%s was already stubbed" % [name.to_s]
+      raise StubError, "method :#{name.to_s} was already stubbed"
     end
 
     metaclass = class << self; self; end

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -200,7 +200,7 @@ class Object
     new_name = "__minitest_stub__#{name}"
 
     if respond_to? new_name
-      raise StubError, "method :#{name.to_s} was already stubbed"
+      raise StubError, "method :#{name} was already stubbed"
     end
 
     metaclass = class << self; self; end

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -199,7 +199,8 @@ class Object
   def stub name, val_or_callable, *block_args
     new_name = "__minitest_stub__#{name}"
 
-    if respond_to? new_name
+    restubbed = respond_to? new_name
+    if restubbed
       raise StubError, "method :#{name} was already stubbed"
     end
 
@@ -227,7 +228,7 @@ class Object
 
     yield self
   ensure
-    unless metaclass.nil?
+    unless restubbed
       metaclass.send :undef_method, name
       metaclass.send :alias_method, name, new_name
       metaclass.send :undef_method, new_name

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -1,5 +1,5 @@
 class MockExpectationError < StandardError; end # :nodoc:
-class MultipleStubError < StandardError; end # :nodoc:
+class StubError < StandardError; end # :nodoc:
 
 module Minitest # :nodoc:
 
@@ -200,7 +200,7 @@ class Object
     new_name = "__minitest_stub__#{name}"
 
     if respond_to? new_name
-      raise MultipleStubError, "method :%s was already stubbed" % [name.to_s]
+      raise StubError, "method :%s was already stubbed" % [name.to_s]
     end
 
     metaclass = class << self; self; end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -495,4 +495,18 @@ class TestMinitestStub < Minitest::Test
     @tc.assert_equal true, rs
   end
 
+  def test_blow_up_on_multiple_stub
+    h = {}
+    e = assert_raises MultipleStubError do
+      h.stub(:empty?, false) do
+        h.stub(:empty?, true) do
+          h.empty?
+        end
+      end
+    end
+
+    exp = "method :empty? was already stubbed"
+    @tc.assert_equal exp, e.message
+  end
+
 end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -497,7 +497,7 @@ class TestMinitestStub < Minitest::Test
 
   def test_blow_up_on_multiple_stub
     h = {}
-    e = assert_raises MultipleStubError do
+    e = assert_raises StubError do
       h.stub(:empty?, false) do
         h.stub(:empty?, true) do
           h.empty?


### PR DESCRIPTION
@zamith, here I drafted a possible handling for the multiple stub exception.
Not sure if checking `metaclass.nil?` is the most future proof way to decide not to run the undef/def of the `ensure` block, but in the current state it works. 