### PR TITLE
Add a note to the README to inform about mocks and threads

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -219,6 +219,20 @@ verification to ensure they got all the calls they were expecting."
     end
   end
 
+**Multi-threading and Mocks**
+
+Minitest mocks do not support multi-threading if it works, fine, if it doesn't
+you can use regular ruby patterns and facilities like local variables. Here's
+an example of asserting that code inside a thread is run:
+
+  def test_called_inside_thread
+    called = false
+    pr = Proc.new { called = true }
+    thread = Thread.new(&pr)
+    thread.join
+    assert called, "proc not called"
+  end
+
 === Stubs
 
 Mocks and stubs are defined using terminology by Fowler & Meszaros at


### PR DESCRIPTION
Why:

* In response to #582

This change addresses the need by:

* Adding an example of how to test mocks in a multi-threaded
environment

@zenspider I'm not sure of the tone, but in terms of info I'd say it's there. What do you think?