### PR TITLE
Add assert_raises_with_message

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -318,6 +318,19 @@ module Minitest
     end
 
     ##
+    # Fails unless the block raises +err+ with the message +err_msg+.
+
+    def assert_raises_with_message err, err_msg, msg = nil
+      e = assert_raises(err, msg) { yield }
+      if err_msg != e.message
+        flunk message(msg) {
+          diff_message = diff err_msg, e.message
+          "#{e.class} raised with unexpected message\n#{diff_message}"
+        }
+      end
+    end
+
+    ##
     # Fails unless +obj+ responds to +meth+.
 
     def assert_respond_to obj, meth, msg = nil

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -1176,6 +1176,30 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_raises_with_message
+    @tc.assert_raises_with_message RuntimeError, "blah" do
+      raise "blah"
+    end
+  end
+
+  def test_assert_raises_with_message_triggered
+    @assertion_count = 2
+    e = assert_raises Minitest::Assertion do
+      @tc.assert_raises_with_message RuntimeError, "blah" do
+        raise "foo"
+      end
+    end
+
+    expected = clean <<-EOM.chomp
+      RuntimeError raised with unexpected message
+      Expected: "blah"
+        Actual: "foo".
+    EOM
+
+    assert_equal expected, e.message
+  end
+
+
   ##
   # *sigh* This is quite an odd scenario, but it is from real (albeit
   # ugly) test code in ruby-core:
@@ -1433,8 +1457,8 @@ class TestMinitestUnitTestCase < Minitest::Test
 
     # These don't have corresponding refutes _on purpose_. They're
     # useless and will never be added, so don't bother.
-    ignores = %w[assert_output assert_raises assert_send
-                 assert_silent assert_throws]
+    ignores = %w[assert_output assert_raises assert_raises_with_message
+                 assert_send assert_silent assert_throws]
 
     # These are test/unit methods. I'm not actually sure why they're still here
     ignores += %w[assert_no_match assert_not_equal assert_not_nil


### PR DESCRIPTION
This adds support to `assert_raises_with_message`. The usage is straightforward:
```ruby
assert_raises_with_message RuntimeError, "expected error message"
```

and in case of failure, it gives us a message like this:

```
RuntimeError raised with unexpected message
Expected: "blah"
  Actual: "foo".
```

It relies on `assert_raises`, so if no exception or an unexpected exception is raised, the behavior is the same as `assert_raises`.

Would love some feedback to know if this is a feature you'd like to see included and if the implementation looks good.

Thank you.
