### PR TITLE
Remove outdated documentation

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -139,9 +139,6 @@ module Minitest
   ##
   # Internal run method. Responsible for telling all Runnable
   # sub-classes to run.
-  #
-  # NOTE: this method is redefined in parallel_each.rb, which is
-  # loaded if a Runnable calls parallelize_me!.
 
   def self.__run reporter, options
     suites = Runnable.runnables.shuffle


### PR DESCRIPTION
Remove outdated documentation since `parallel_each.rb` doesn't exist anymore and `run_one_method` is the method that `parallel.rb` overrides.