### PR TITLE
Mention make_my_diffs_pretty! in assert_equal docs

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -152,7 +152,8 @@ module Minitest
     #
     # If there is no visible difference but the assertion fails, you
     # should suspect that your #== is buggy, or your inspect output is
-    # missing crucial details.
+    # missing crucial details.  For nicer hash diffing, set
+    # Minitest::Test.make_my_diffs_pretty!
     #
     # For floats use assert_in_delta.
     #

--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -152,7 +152,7 @@ module Minitest
     #
     # If there is no visible difference but the assertion fails, you
     # should suspect that your #== is buggy, or your inspect output is
-    # missing crucial details.  For nicer hash diffing, set
+    # missing crucial details.  For nicer structural diffing, set
     # Minitest::Test.make_my_diffs_pretty!
     #
     # For floats use assert_in_delta.


### PR DESCRIPTION
When comparing hashes together Hash#inspect prints the hash entries all on a single line, but pp prints a line for each entry.  This is similar to Gem::TestCase#mu_pp