### PR TITLE
Pluralize final summary report line

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -620,11 +620,9 @@ module Minitest
          extra]
     end
 
-    def simple_pluralize(n, singular, plural=nil)
+    def simple_pluralize(n, singular)
       if n == 1
           "1 #{singular}"
-      elsif plural
-          "#{n} #{plural}"
       else
           "#{n} #{singular}s"
       end

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -610,9 +610,26 @@ module Minitest
       extra = "\n\nYou have skipped tests. Run with --verbose for details." if
         results.any?(&:skipped?) unless options[:verbose] or ENV["MT_NO_SKIP_MSG"]
 
-      "%d runs, %d assertions, %d failures, %d errors, %d skips%s" %
-        [count, assertions, failures, errors, skips, extra]
+      # list counts for runs, assertions, failures, errors, skips, and extra
+      "%s, %s, %s, %s, %s%s" %
+        [simple_pluralize(count, "run"),
+         simple_pluralize(assertions, "assertion"),
+         simple_pluralize(failures, "failure"),
+         simple_pluralize(errors, "error"),
+         simple_pluralize(skips, "skip"),
+         extra]
     end
+
+    def simple_pluralize(n, singular, plural=nil)
+      if n == 1
+          "1 #{singular}"
+      elsif plural
+          "#{n} #{plural}"
+      else
+          "#{n} #{singular}s"
+      end
+    end
+
   end
 
   ##

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -198,7 +198,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 0 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 0 assertions, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_equal exp, normalize_output(io.string)
@@ -222,7 +222,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
       Minitest::Test#woot [FILE:LINE]:
       boo
 
-      1 runs, 0 assertions, 1 failures, 0 errors, 0 skips
+      1 run, 0 assertions, 1 failure, 0 errors, 0 skips
     EOM
 
     assert_equal exp, normalize_output(io.string)
@@ -248,7 +248,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
           FILE:LINE:in `error_test'
           FILE:LINE:in `test_report_error'
 
-      1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
+      1 run, 0 assertions, 0 failures, 1 error, 0 skips
     EOM
 
     assert_equal exp, normalize_output(io.string)
@@ -271,7 +271,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 0 assertions, 0 failures, 0 errors, 1 skips
+      1 run, 0 assertions, 0 failures, 0 errors, 1 skip
 
       You have skipped tests. Run with --verbose for details.
     EOM

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -177,7 +177,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_report expected
@@ -205,7 +205,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
       RuntimeError: unhandled exception
           FILE:LINE:in \`test_error\'
 
-      2 runs, 1 assertions, 0 failures, 1 errors, 0 skips
+      2 runs, 1 assertion, 0 failures, 1 error, 0 skips
     EOM
 
     assert_report expected
@@ -233,7 +233,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
       RuntimeError: unhandled exception
           FILE:LINE:in \`teardown\'
 
-      1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 1 error, 0 skips
     EOM
 
     assert_report expected
@@ -251,7 +251,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
       #<Class:0xXXX>#test_failure [FILE:LINE]:
       Expected false to be truthy.
 
-      2 runs, 2 assertions, 1 failures, 0 errors, 0 skips
+      2 runs, 2 assertions, 1 failure, 0 errors, 0 skips
     EOM
 
     assert_report expected
@@ -278,7 +278,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_report expected, %w[--name /some|thing/ --seed 42]
@@ -315,7 +315,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_filtering 'name', "/Beta#test_something/", expected
@@ -327,7 +327,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_filtering 'name', "Beta#test_something", expected
@@ -353,7 +353,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_report expected, %w[--exclude /failure/ --seed 42]
@@ -365,7 +365,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_filtering 'exclude', "/Alpha#test_something/", expected
@@ -377,7 +377,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_filtering 'exclude', "Alpha#test_something", expected
@@ -408,7 +408,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+      1 run, 1 assertion, 0 failures, 0 errors, 0 skips
     EOM
 
     assert_report expected
@@ -431,7 +431,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
 
       Finished in 0.00
 
-      2 runs, 1 assertions, 0 failures, 0 errors, 1 skips
+      2 runs, 1 assertion, 0 failures, 0 errors, 1 skip
 
       You have skipped tests. Run with --verbose for details.
     EOM
@@ -463,7 +463,7 @@ class TestMinitestRunner < MetaMetaMetaTestCase
       #<Class:0xXXX>#test_skip [FILE:LINE]:
       not yet
 
-      2 runs, 1 assertions, 0 failures, 0 errors, 1 skips
+      2 runs, 1 assertion, 0 failures, 0 errors, 1 skip
     EOM
 
     assert_report expected, %w[--seed 42 --verbose]


### PR DESCRIPTION
This is my first real pull request, so please forgive me if I'm doing it wrong.  I just went to Ruby on Ales and was inspired by the talks (including zenspider's) to finally give contributing a go.  I wasn't sure where to put the utility method `#simple_pluralize`, so I left it under `#summary` for now.  I also see that there are some other areas where pluralization could be used, but I wanted to run this by seattlerb first before continuing incase there are good reasons to not pluralize reporting.  Also, any advice in helping me become a better contributor would be much appreciated.