### PR TITLE
Remove Interrupt from PASSTHROUGH_EXCEPTIONS

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -11,8 +11,7 @@ module Minitest
     require "minitest/assertions"
     include Minitest::Assertions
 
-    PASSTHROUGH_EXCEPTIONS = [NoMemoryError, SignalException, # :nodoc:
-                              Interrupt, SystemExit]
+    PASSTHROUGH_EXCEPTIONS = [NoMemoryError, SignalException, SystemExit] # :nodoc:
 
     class << self; attr_accessor :io_lock; end # :nodoc:
     self.io_lock = Mutex.new


### PR DESCRIPTION
As Interrupt is also a SignalException we don't need to explicitly put it into the array.

```
Interrupt.ancestors # => [Interrupt, SignalException, ... ]
```

