### PR TITLE
Fix assert_throw rescuing any NameError and ArgumentError

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -386,8 +386,10 @@ module Minitest
         rescue ThreadError => e       # wtf?!? 1.8 + threads == suck
           default += ", not \:#{e.message[/uncaught throw \`(\w+?)\'/, 1]}"
         rescue ArgumentError => e     # 1.9 exception
+          raise e unless e.message.include?("uncaught throw")
           default += ", not #{e.message.split(/ /).last}"
         rescue NameError => e         # 1.8 exception
+          raise e unless e.name == sym
           default += ", not #{e.name.inspect}"
         end
         caught = false

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1466,6 +1466,22 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_throws_name_error
+    @tc.assert_raises NameError do
+      @tc.assert_throws :blah do
+        raise NameError
+      end
+    end
+  end
+
+  def test_assert_throws_argument_exception
+    @tc.assert_raises ArgumentError do
+      @tc.assert_throws :blah do
+        raise ArgumentError
+      end
+    end
+  end
+
   def test_assert_throws_different
     assert_triggered "Expected :blah to have been thrown, not :not_blah." do
       @tc.assert_throws :blah do


### PR DESCRIPTION
Fix #622 

`throw` have different behavior depending on Ruby version:
- Ruby 1.8 raises `NameError` with `name` equal to the `throw`'s  `tag`
- Ruby 1.9 raises `ArgumentError` with the following `message`: `uncaught throw #{throw's tag}`
- Ruby 2.2 raises `UncaughtThrowError` which is also an `ArgumentError` and is handled accordingly.

So the simplest solution is to re-raise the exception in case of a different source other than the `throw` 