### PR TITLE
`assert_equal` should not allow `nil` for "expected"

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -170,6 +170,7 @@ module Minitest
     # See also: Minitest::Assertions.diff
 
     def assert_equal exp, act, msg = nil
+      raise ArgumentError, "use assert_nil if expecting nil" if exp.nil?
       msg = message(msg, E) { diff exp, act }
       assert exp == act, msg
     end

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -20,6 +20,13 @@ class TestMinitestUnit < MetaMetaMetaTestCase
                "#{MINITEST_BASE_DIR}/test.rb:139:in `run'",
                "#{MINITEST_BASE_DIR}/test.rb:106:in `run'"]
 
+  def test_assert_equal_does_not_allow_lhs_nil
+    exp = assert_raises(ArgumentError) do
+      assert_equal nil, Object.new
+    end
+    assert_equal "use assert_nil if expecting nil", exp.message
+  end
+
   def test_filter_backtrace
     # this is a semi-lame mix of relative paths.
     # I cheated by making the autotest parts not have ./

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -21,7 +21,7 @@ class TestMinitestUnit < MetaMetaMetaTestCase
                "#{MINITEST_BASE_DIR}/test.rb:106:in `run'"]
 
   def test_assert_equal_does_not_allow_lhs_nil
-    exp = assert_raises(ArgumentError) do
+    exp = assert_raises ArgumentError do
       assert_equal nil, Object.new
     end
     assert_equal "use assert_nil if expecting nil", exp.message


### PR DESCRIPTION
If you are expecting the value to be nil, you should be using
`assert_nil` rather than passing `nil` in for the expected value.  This
helps shorten your code, and also helps prevent situations where the
expected value becomes `nil` accidentally.

I wasn't sure what exception this should raise, so I just went with `ArgumentError`.