### PR TITLE
Don't shuffle runnables unless :random or :parallel

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -147,7 +147,13 @@ module Minitest
   # sub-classes to run.
 
   def self.__run reporter, options
-    suites = Runnable.runnables.shuffle
+    suites = case Minitest::Test.test_order
+    when :random, :parallel then
+      Runnable.runnables.shuffle
+    else
+      Runnable.runnables
+    end
+
     parallel, serial = suites.partition { |s| s.test_order == :parallel }
 
     # If we run the parallel tests before the serial tests, the parallel tests

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -158,7 +158,7 @@ module Minitest
     when :random then
       Runnable.runnables.shuffle
     else
-      Runnable.runnables.sort_by { |r| r.name }
+      Runnable.runnables
     end
 
     if Minitest.suite_order == :random

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -45,6 +45,12 @@ module Minitest
   mc.send :attr_accessor, :info_signal
   self.info_signal = "INFO"
 
+  SUITE_ORDERINGS = [:sorted, :random]
+
+  def self.suite_order
+    @@suite_order || :random
+  end
+
   ##
   # Registers Minitest to run at process exit
 
@@ -120,6 +126,7 @@ module Minitest
     self.load_plugins
 
     options = process_args args
+    @@suite_order = options[:order]
 
     reporter = CompositeReporter.new
     reporter << SummaryReporter.new(options[:io], options)
@@ -147,22 +154,26 @@ module Minitest
   # sub-classes to run.
 
   def self.__run reporter, options
-    suites = case Minitest::Test.test_order
-    when :random, :parallel then
+    suites = case suite_order
+    when :random then
       Runnable.runnables.shuffle
     else
-      Runnable.runnables
+      Runnable.runnables.sort_by { |r| r.name }
     end
 
-    parallel, serial = suites.partition { |s| s.test_order == :parallel }
+    if Minitest.suite_order == :random
+      parallel, serial = suites.partition { |s| s.test_order == :parallel }
 
-    # If we run the parallel tests before the serial tests, the parallel tests
-    # could run in parallel with the serial tests. This would be bad because
-    # the serial tests won't lock around Reporter#record. Run the serial tests
-    # first, so that after they complete, the parallel tests will lock when
-    # recording results.
-    serial.map { |suite| suite.run reporter, options } +
-      parallel.map { |suite| suite.run reporter, options }
+      # If we run the parallel tests before the serial tests, the parallel tests
+      # could run in parallel with the serial tests. This would be bad because
+      # the serial tests won't lock around Reporter#record. Run the serial tests
+      # first, so that after they complete, the parallel tests will lock when
+      # recording results.
+      serial.map { |suite| suite.run reporter, options } +
+        parallel.map { |suite| suite.run reporter, options }
+    else
+      suites.map { |suite| suite.run reporter, options }
+    end
   end
 
   def self.process_args args = [] # :nodoc:
@@ -195,6 +206,12 @@ module Minitest
 
       opts.on "-e", "--exclude PATTERN", "Exclude /regexp/ or string from run." do |a|
         options[:exclude] = a
+      end
+
+      opts.on "-o", "--order ORDER", "Order to run test suites in parallel, random, sorted." do |a|
+        order = a.to_sym
+        raise OptionParser::InvalidOption, "Order must be parallel, random, sorted or fixed" unless SUITE_ORDERINGS.include? order
+        options[:order] = order
       end
 
       unless extensions.empty?

--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -22,10 +22,7 @@ module Minitest
     # admitting that you suck and your tests are weak.
 
     def self.i_suck_and_my_tests_are_order_dependent!
-      class << self
-        undef_method :test_order if method_defined? :test_order
-        define_method :test_order do :alpha end
-      end
+      @test_order = :alpha
     end
 
     ##
@@ -52,6 +49,11 @@ module Minitest
       extend Minitest::Parallel::Test::ClassMethods
     end
 
+    def self.run reporter, options
+      @test_order = options[:order] if options[:order]
+      super
+    end
+
     ##
     # Returns all instance methods starting with "test_". Based on
     # #test_order, the methods are either sorted, randomized
@@ -76,7 +78,7 @@ module Minitest
     # this or use a convenience method to change it for your tests.
 
     def self.test_order
-      :random
+      @test_order ||= :random
     end
 
     ##


### PR DESCRIPTION
Don't shuffle Runnable.runnables when running tests with test_order set to :random or :parallel.

I have not added any test for this as there doesn't seem to be any place where this part of the test runner is currently being tested.

I also considered it might make sense to encapsulate this logic in the `Runnable` class. This would probably be easier to write unit tests for as well.