### PR TITLE
Accept floating point inconsistencies in bench_exp

### DIFF
--- a/lib/minitest/benchmark.rb
+++ b/lib/minitest/benchmark.rb
@@ -33,8 +33,8 @@ module Minitest
     #   bench_exp(2, 16, 2) # => [2, 4, 8, 16]
 
     def self.bench_exp min, max, base = 10
-      min = (Math.log10(min) / Math.log10(base)).to_i
-      max = (Math.log10(max) / Math.log10(base)).to_i
+      min = (Math.log10(min) / Math.log10(base)).ceil
+      max = (Math.log10(max) / Math.log10(base)).ceil
 
       (min..max).map { |m| base ** m }.to_a
     end

--- a/test/minitest/test_minitest_benchmark.rb
+++ b/test/minitest/test_minitest_benchmark.rb
@@ -8,6 +8,7 @@ require "minitest/benchmark"
 class TestMinitestBenchmark < Minitest::Test
   def test_cls_bench_exp
     assert_equal [2, 4, 8, 16, 32], Minitest::Benchmark.bench_exp(2, 32, 2)
+    assert_equal 7, Minitest::Benchmark.bench_exp(1, 1_000_000).size
   end
 
   def test_cls_bench_linear


### PR DESCRIPTION
On JRuby:

```
>> JRUBY_VERSION
=> "9.1.2.0"
>> (Math.log10(1_000_000) / Math.log10(10))
=> 5.999999999999999
```

On MRI:

```
>> RUBY_VERSION
=> "2.3.0"
>> (Math.log10(1_000_000) / Math.log10(10))
=> 6.0
```

This causes bench_exp to give different results depending on the ruby implementation. I ran into it specifically when trying to benchmark differences between MRI and JRuby. I was making some false conclusions before I realized JRuby wasn't running in the same race.