### PR TITLE
Fixed code example with inproper casing

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -97,7 +97,7 @@ Define your tests as methods beginning with +test_+.
 
   require "minitest/autorun"
 
-  class TestMeme < Minitest::Test
+  class TestMeme < MiniTest::Test
     def setup
       @meme = Meme.new
     end


### PR DESCRIPTION
MiniTest was spelled as "Minitest" in the Readme example.