### PR TITLE
Write strings directly to the IO object

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -593,7 +593,7 @@ module Minitest
       filtered_results = results.dup
       filtered_results.reject!(&:skipped?) unless options[:verbose]
 
-      filtered_results.each_with_index.each { |result, i|
+      filtered_results.each_with_index { |result, i|
         io.puts "\n%3d) %s" % [i+1, result]
       }
       io.puts

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -2,6 +2,7 @@ require "optparse"
 require "thread"
 require "mutex_m"
 require "minitest/parallel"
+require "stringio"
 
 ##
 # :include: README.rdoc
@@ -579,7 +580,7 @@ module Minitest
       io.puts unless options[:verbose] # finish the dots
       io.puts
       io.puts statistics
-      io.puts aggregated_results
+      aggregated_results io
       io.puts summary
     end
 
@@ -588,21 +589,20 @@ module Minitest
         [total_time, count / total_time, assertions / total_time]
     end
 
-    def aggregated_results # :nodoc:
+    def aggregated_results io # :nodoc:
       filtered_results = results.dup
       filtered_results.reject!(&:skipped?) unless options[:verbose]
 
-      s = filtered_results.each_with_index.map { |result, i|
-        "\n%3d) %s" % [i+1, result]
-      }.join("\n") + "\n"
-
-      s.force_encoding(io.external_encoding) if
-        ENCS and io.external_encoding and s.encoding != io.external_encoding
-
-      s
+      filtered_results.each_with_index.each { |result, i|
+        io.puts "\n%3d) %s" % [i+1, result]
+      }
+      io.puts
+      io
     end
 
-    alias to_s aggregated_results
+    def to_s
+      aggregated_results(StringIO.new(''.b)).string
+    end
 
     def summary # :nodoc:
       extra = ""

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -601,7 +601,7 @@ module Minitest
     end
 
     def to_s
-      aggregated_results(StringIO.new(''.b)).string
+      aggregated_results(StringIO.new(binary_string)).string
     end
 
     def summary # :nodoc:
@@ -612,6 +612,14 @@ module Minitest
 
       "%d runs, %d assertions, %d failures, %d errors, %d skips%s" %
         [count, assertions, failures, errors, skips, extra]
+    end
+
+    private
+
+    if '<3'.respond_to? :b
+      def binary_string; ''.b; end
+    else
+      def binary_string; ''.force_encoding(Encoding::ASCII_8BIT); end
     end
   end
 

--- a/test/minitest/metametameta.rb
+++ b/test/minitest/metametameta.rb
@@ -14,7 +14,7 @@ class MetaMetaMetaTestCase < Minitest::Test
   def run_tu_with_fresh_reporter flags = %w[--seed 42]
     options = Minitest.process_args flags
 
-    @output = StringIO.new("")
+    @output = StringIO.new("".encode('UTF-8'))
 
     self.reporter = Minitest::CompositeReporter.new
     reporter << Minitest::SummaryReporter.new(@output, options)

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -74,6 +74,12 @@ class TestMinitestReporter < MetaMetaMetaTestCase
     @st
   end
 
+  def test_to_s
+    r.record passing_test
+    r.record fail_test
+    assert_match "woot", r.first.to_s
+  end
+
   def test_passed_eh_empty
     assert r.passed?
   end

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -66,6 +66,38 @@ class TestMinitestUnit < MetaMetaMetaTestCase
   #   assert_instance_of Minitest::Unit, Minitest::Unit.runner
   # end
 
+  def test_infectious_binary_encoding
+    @tu = Class.new Minitest::Test do
+      def test_this_is_not_ascii_assertion
+        assert_equal "ЁЁЁ", "ёёё"
+      end
+
+      def test_this_is_non_ascii_failure_message
+        fail 'ЁЁЁ'.force_encoding('ASCII-8BIT')
+      end
+    end
+
+    expected = clean <<-EOM
+      EF
+
+      Finished in 0.00
+
+        1) Error:
+      #<Class:0xXXX>#test_this_is_non_ascii_failure_message:
+      RuntimeError: ЁЁЁ
+          FILE:LINE:in `test_this_is_non_ascii_failure_message'
+
+        2) Failure:
+      #<Class:0xXXX>#test_this_is_not_ascii_assertion [FILE:LINE]:
+      Expected: \"ЁЁЁ\"
+        Actual: \"ёёё\"
+      
+      2 runs, 1 assertions, 1 failures, 1 errors, 0 skips
+    EOM
+
+    assert_report expected
+  end
+
   def test_passed_eh_teardown_good
     test_class = Class.new Minitest::Test do
       def teardown; assert true; end


### PR DESCRIPTION
$stdout has binary output by default, so we can write any old bytes we'd
like to write.  Writing one test failure result at a time allows us to
avoid dealing with encoding issues when doing string concatenation

Fixes #649
