### PR TITLE
Add assert_boolean and refute_boolean

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -207,6 +207,16 @@ module Minitest
     end
 
     ##
+    # Fails unless +obj+ is true or false.
+
+    def assert_boolean obj, msg = nil
+      msg = message(msg) {
+        "Expected #{mu_pp(obj)} to be true or false"
+      }
+      assert [true, false].include?(obj), msg
+    end
+
+    ##
     # Fails unless +collection+ includes +obj+.
 
     def assert_includes collection, obj, msg = nil
@@ -572,6 +582,16 @@ module Minitest
 
     def refute_in_epsilon a, b, epsilon = 0.001, msg = nil
       refute_in_delta a, b, a * epsilon, msg
+    end
+
+    ##
+    # Fails if +obj+ is true or false.
+
+    def refute_boolean obj, msg = nil
+      msg = message(msg) {
+        "Expected #{mu_pp(obj)} to not be true or false"
+      }
+      refute [true, false].include?(obj), msg
     end
 
     ##

--- a/lib/minitest/expectations.rb
+++ b/lib/minitest/expectations.rb
@@ -57,6 +57,15 @@ module Minitest::Expectations
   infect_an_assertion :assert_in_epsilon, :must_be_within_epsilon
 
   ##
+  # See Minitest::Assertions#assert_boolean
+  #
+  #    collection.must_be_boolean
+  #
+  # :method: must_be_boolean
+
+  infect_an_assertion :assert_boolean, :must_be_boolean, :unary
+
+  ##
   # See Minitest::Assertions#assert_includes
   #
   #    collection.must_include obj
@@ -205,6 +214,15 @@ module Minitest::Expectations
   # :method: wont_be_within_epsilon
 
   infect_an_assertion :refute_in_epsilon, :wont_be_within_epsilon
+
+  ##
+  # See Minitest::Assertions#refute_boolean
+  #
+  #    collection.wont_be_boolean
+  #
+  # :method: wont_be_boolean
+
+  infect_an_assertion :refute_boolean, :wont_be_boolean, :unary
 
   ##
   # See Minitest::Assertions#refute_includes

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -57,6 +57,30 @@ describe Minitest::Spec do
     end
   end
 
+  it "needs to verify boolean" do
+    true.must_be_boolean.must_equal true
+
+    assert_triggered "Expected nil to be true or false." do
+      nil.must_be_boolean
+    end
+
+    assert_triggered "msg.\nExpected nil to be true or false." do
+      nil.must_be_boolean "msg"
+    end
+  end
+
+  it "needs to verify non-boolean" do
+    nil.wont_be_boolean.must_equal false
+
+    assert_triggered "Expected true to not be true or false." do
+      true.wont_be_boolean
+    end
+
+    assert_triggered "msg.\nExpected true to not be true or false." do
+      true.wont_be_boolean "msg"
+    end
+  end
+
   it "needs to be sensible about must_include order" do
     @assertion_count += 3 # must_include is 2 assertions
 
@@ -131,6 +155,7 @@ describe Minitest::Spec do
     musts, wonts = methods.sort.partition { |m| m =~ /^must/ }
 
     expected_musts = %w[must_be
+                        must_be_boolean
                         must_be_close_to
                         must_be_empty
                         must_be_instance_of

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1065,6 +1065,10 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_boolean
+    @tc.assert_boolean true
+  end
+
   def test_assert_includes
     @assertion_count = 2
 
@@ -1693,6 +1697,10 @@ class TestMinitestUnitTestCase < Minitest::Test
       @tc.refute_in_epsilon 10_000, 9990
       flunk
     end
+  end
+
+  def test_refute_boolean
+    @tc.refute_boolean nil
   end
 
   def test_refute_includes


### PR DESCRIPTION
I can not write below code with MiniTest;

```ruby
assert_instance_of(Boolean, value)
```

because Ruby doesn't have `Boolean` class, `true` is the only instance of `TrueClass` and `false` is the only instance of `FalseClass`.

On another front, [test-unit has `assert_boolean`](https://github.com/test-unit/test-unit/blob/c31f9d017eaf899331fadf4c5bb4943bea7ed3c6/lib/test/unit/assertions.rb#L1193-L1207). I think that the assertion is so useful.

```ruby
assert_boolean(true) # => pass
assert_boolean(false) # => pass
assert_boolean(nil) # => fail
```

This Pull Request adds `assert_boolean` and `refute_boolean` to MiniTest.