### PR TITLE
WIP: fix minitest/hell

### DIFF
--- a/lib/minitest/hell.rb
+++ b/lib/minitest/hell.rb
@@ -1,6 +1,9 @@
 require "minitest/parallel"
 
 class Minitest::Test
+  include Minitest::Parallel::Test
+  extend Minitest::Parallel::Test::ClassMethods
+
   class << self
     alias :old_test_order :test_order # :nodoc:
 

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -57,7 +57,11 @@ module Minitest
 
       module ClassMethods # :nodoc:
         def run_one_method klass, method_name, reporter
-          Minitest.parallel_executor << [klass, method_name, reporter]
+          if test_order == :parallel
+            Minitest.parallel_executor << [klass, method_name, reporter]
+          else
+            super
+          end
         end
 
         def test_order

--- a/test/minitest/test_minitest_hell.rb
+++ b/test/minitest/test_minitest_hell.rb
@@ -1,0 +1,88 @@
+require 'minitest/metametameta'
+require 'minitest/hell'
+
+class TestMinitestHell < MetaMetaMetaTestCase
+  def self.test_order
+    :random
+  end
+
+  require "monitor"
+
+  class Latch
+    def initialize count = 1
+      @count = count
+      @lock  = Monitor.new
+      @cv    = @lock.new_cond
+    end
+
+    def release
+      @lock.synchronize do
+        @count -= 1 if @count > 0
+        @cv.broadcast if @count == 0
+      end
+    end
+
+    def await
+      @lock.synchronize { @cv.wait_while { @count > 0 } }
+    end
+  end
+
+  def test_run_parallel
+    skip "I don't have ParallelEach debugged yet" if maglev?
+
+    test_count = 2
+    test_latch = Latch.new test_count
+    wait_latch = Latch.new test_count
+    main_latch = Latch.new
+
+    thread = Thread.new {
+      Thread.current.abort_on_exception = true
+
+      # This latch waits until both test latches have been released.  Both
+      # latches can't be released unless done in separate threads because
+      # `main_latch` keeps the test method from finishing.
+      test_latch.await
+      main_latch.release
+    }
+
+    @tu =
+    Class.new FakeNamedTest do
+
+      test_count.times do |i|
+        define_method :"test_wait_on_main_thread_#{i}" do
+          test_latch.release
+
+          # This latch blocks until the "main thread" releases it. The main
+          # thread can't release this latch until both test latches have
+          # been released.  This forces the latches to be released in separate
+          # threads.
+          main_latch.await
+          assert true
+        end
+      end
+    end
+
+    expected = clean <<-EOM
+      ..
+
+      Finished in 0.00
+
+      2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
+    EOM
+
+    assert_report(expected) do |reporter|
+      reporter.extend(Module.new {
+        define_method("record") do |result|
+          super(result)
+          wait_latch.release
+        end
+
+        define_method("report") do
+          wait_latch.await
+          super()
+        end
+      })
+    end
+    assert thread.join
+  end
+end

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -146,6 +146,9 @@ end
 
 class TestMinitestRunner < MetaMetaMetaTestCase
   # do not parallelize this suite... it just can't handle it.
+  def self.test_order
+    :random
+  end
 
   def test_class_runnables
     @assertion_count = 0
@@ -592,6 +595,9 @@ end
 
 class TestMinitestUnitOrder < MetaMetaMetaTestCase
   # do not parallelize this suite... it just can't handle it.
+  def self.test_order
+    :random
+  end
 
   def test_before_setup
     call_order = []
@@ -748,6 +754,9 @@ class TestMinitestUnitTestCase < Minitest::Test
   # do not call parallelize_me! - teardown accesses @tc._assertions
   # which is not threadsafe. Nearly every method in here is an
   # assertion test so it isn't worth splitting it out further.
+  def self.test_order
+    :random
+  end
 
   RUBY18 = !defined? Encoding
 
@@ -1937,6 +1946,9 @@ end
 
 class TestMinitestUnitRecording < MetaMetaMetaTestCase
   # do not parallelize this suite... it just can't handle it.
+  def self.test_order
+    :random
+  end
 
   def assert_run_record *expected, &block
     @tu = Class.new FakeNamedTest, &block


### PR DESCRIPTION
Since Minitest::Test was never extended with
  Minitest::Parallel::Test::ClassMethods
changing the test_order had no effect.
Once you extend it a test_order of :random has no effect either.

This fix includes a test that confirms minitest/hell does what it is
supposed to do. However requiring this test will require minitest/hell
and thus break the other tests. I tried to work around this by setting
the test order explecitly in those tests but it does not seem to help.