### PR TITLE
apply filter_backtrace in assert_send deprecation

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -370,7 +370,9 @@ module Minitest
     # Fails unless the call returns a true value
 
     def assert_send send_ary, m = nil
-      warn "DEPRECATED: assert_send. From #{caller.first}"
+      where = Minitest.filter_backtrace(caller).first
+      where = where.split(/:in /, 2).first # clean up noise
+      warn "DEPRECATED: assert_send. From #{where}"
 
       recv, msg, *args = send_ary
       m = message(m) {


### PR DESCRIPTION
When using RSpec and Rails, calls are _delegated_ to Minitest making deprecation messages point to code in the `rspec-rails` gem.

With this change, any deprecations for `assert_send` (or `assert_nil` which already filtered its backtrace) *can* be filtered by chaining your own filter such as by putting this into `spec/support/backtrace_filter.rb`:

```ruby
class BacktraceFilter # :nodoc:
  def initialize(btf=nil)
    @upstream_filter = btf unless btf.nil?
  end

  def filter bt
    return ["No backtrace"] unless bt

    return bt.dup if $DEBUG

    gems_re = %r%vendor/%

    bt = @upstream_filter.filter bt if @upstream_filter

    new_bt = bt.take_while { |line| line !~ gems_re }
    new_bt = bt.select     { |line| line !~ gems_re } if new_bt.empty?
    new_bt = bt.dup                                   if new_bt.empty?

    new_bt
  end
end

require 'minitest'
Minitest.backtrace_filter = BacktraceFilter.new(Minitest.backtrace_filter)
```