### PR TITLE
Expand MT6 to Minitest 6.

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -180,7 +180,7 @@ module Minitest
           where = Minitest.filter_backtrace(caller).first
           where = where.split(/:in /, 2).first # clean up noise
 
-          $stderr.puts "Use assert_nil if expecting nil from #{where}. This will fail in MT6."
+          $stderr.puts "Use assert_nil if expecting nil from #{where}. This will fail in Minitest 6."
         end
       end
 

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -224,7 +224,7 @@ describe Minitest::Spec do
     end
 
     exp = "Use assert_nil if expecting nil from #{__FILE__}:#{__LINE__-3}. " \
-      "This will fail in MT6.\n"
+      "This will fail in Minitest 6.\n"
 
     assert_empty out
     assert_equal exp, err


### PR DESCRIPTION
It's non-obvious what the acronym means, particularly when minitest has
been pulled in via a different library (such as Rails) and the user may
not be aware they are using minitest.

This confused at least me and one other person (on
https://github.com/rspec/rspec-rails/issues/1761)