### PR TITLE
README.rdoc updates for common Windows problems

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -452,6 +452,60 @@ able to require minitest and run your tests.
 * rdoc
 * ...and of course, everything from seattle.rb...
 
+== Developing Minitest:
+
+=== Minitest's own tests require UTF-8 external encoding.
+
+This is a common problem in Windows, where the default external Encoding is
+often CP850, but can affect any platform.
+Minitest can run test suites using any Encoding, but to run Minitest's
+own tests you must have a default external Encoding of UTF-8.
+
+If your encoding is wrong, you'll see errors like:
+
+    --- expected
+    +++ actual
+    @@ -1,2 +1,3 @@
+     # encoding: UTF-8
+     -"Expected /\\w+/ to not match \"blah blah blah\"."
+     +"Expected /\\w+/ to not match # encoding: UTF-8
+     +\"blah blah blah\"."
+
+To check your current encoding, run:
+
+    ruby -e 'puts Encoding.default_external'
+
+If your output is something other than UTF-8, you can set the RUBYOPTS
+env variable to a value of '-Eutf-8'. Something like:
+
+    RUBYOPT='-Eutf-8' ruby -e 'puts Encoding.default_external'
+
+Check your OS/shell documentation for the precise syntax (the above
+will not work on a basic Windows CMD prompt, look for the SET command).
+Once you've got it successfully outputing UTF-8, use the same setting
+when running rake in Minitest.
+
+=== Minitest's own tests require GNU (or similar) diff.
+
+This is also a problem primarily affecting Windows developers. PowerShell
+has a command called diff, but it is not suitable for use with Minitest.
+
+If you use Cygwin or MSYS2 or similar there are packages that include a
+GNU diff for Widnows. If you don't, you can download GNU diffutils from
+http://gnuwin32.sourceforge.net/packages/diffutils.htm
+(make sure to add it to your PATH).
+
+You can make sure it's installed and path is configured properly with:
+
+    diff.exe -v
+
+There are multiple lines of output, the first should be something like:
+
+    diff (GNU diffutils) 2.8.1
+
+If you are using PowerShell make sure you run diff.exe, not just diff,
+which will invoke the PowerShell built in function.
+
 == Known Extensions:
 
 capybara_minitest_spec      :: Bridge between Capybara RSpec matchers and

--- a/README.rdoc
+++ b/README.rdoc
@@ -490,6 +490,21 @@ when running rake in Minitest.
 This is also a problem primarily affecting Windows developers. PowerShell
 has a command called diff, but it is not suitable for use with Minitest.
 
+If you see failures like either of these, you are probably missing diff tool:
+
+      4) Failure:
+    TestMinitestUnitTestCase#test_assert_equal_different_long [D:/ruby/seattlerb/minitest/test/minitest/test_minitest_test.rb:936]:
+    Expected: "--- expected\n+++ actual\n@@ -1 +1 @@\n-\"hahahahahahahahahahahahahahahahahahahaha\"\n+\"blahblahblahblahblahblahblahblahblahblah\"\n"
+      Actual: "Expected: \"hahahahahahahahahahahahahahahahahahahaha\"\n  Actual: \"blahblahblahblahblahblahblahblahblahblah\""
+
+
+      5) Failure:
+    TestMinitestUnitTestCase#test_assert_equal_different_collection_hash_hex_invisible [D:/ruby/seattlerb/minitest/test/minitest/test_minitest_test.rb:845]:
+    Expected: "No visible difference in the Hash#inspect output.\nYou should look at the implementation of #== on Hash or its members.\n
+    {1=>#<Object:0xXXXXXX>}"
+      Actual: "Expected: {1=>#<Object:0x00000003ba0470>}\n  Actual: {1=>#<Object:0x00000003ba0448>}"
+
+
 If you use Cygwin or MSYS2 or similar there are packages that include a
 GNU diff for Widnows. If you don't, you can download GNU diffutils from
 http://gnuwin32.sourceforge.net/packages/diffutils.htm


### PR DESCRIPTION
I've made a section under FAQ covering the two main points I ran into when trying to run Minitest's tests on Windows. It occurred to me that particularly the encoding one is not entirely Windows-specific, so I just called the section Developing Minitest.