### PR TITLE
Fix autorun bug that affects fork exit status in tests

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -58,7 +58,9 @@ module Minitest
 
       exit_code = nil
 
+      pid = Process.pid
       at_exit {
+        next if Process.pid != pid
         @@after_run.reverse_each(&:call)
         exit exit_code || false
       }

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -901,6 +901,20 @@ class TestMinitestUnitTestCase < Minitest::Test
       shitty_test_case.i_suck_and_my_tests_are_order_dependent!
     end
   end
+
+  def test_autorun_does_not_affect_fork_success_status
+    @assertion_count = 0
+    return unless Process.respond_to?(:fork)
+    Process.waitpid(fork {})
+    assert_equal true, $?.success?
+  end
+
+  def test_autorun_does_not_affect_fork_exit_status
+    @assertion_count = 0
+    return unless Process.respond_to?(:fork)
+    Process.waitpid(fork { exit 42 })
+    assert_equal 42, $?.exitstatus
+  end
 end
 
 class TestMinitestGuard < Minitest::Test


### PR DESCRIPTION
## Problem

I was trying to test the exit status of a fork in a test and was getting confused about why it was always resulting in an exit status of 1, even after removing project specific code.  I was able to reproduce it with this simple test file

```ruby
require 'minitest'

class ForkTest < Minitest::Test
  def test_fork
    Process.waitpid(fork {})
    assert_equal true, $?.success?
  end
end

Minitest.autorun
```
which got the test failure
```
  1) Failure:
ForkTest#test_fork [main.rb:7]:
Expected: true
  Actual: false
```

Changing `Minitest.autorun` to `Minitest.run` would cause the test to pass.

The problem was that from the nested `at_exit` block in Minitest.autorun calling `exit exit_code || false` where `exit_code` hadn't been set by the line `exit_code = Minitest.run ARGV` had not set the `exit_code` variable in the fork.

## Solution

Check to see if the process pid has changed to detect when we are in a fork, then skip the rest of the at_exit block if we are in the fork.

In addition to not affecting the exit status of the forked process, this will also avoid running any `Minitest.after_run` blocks, which don't seem like they should be run at the end of a forked process.