### PR TITLE
Fixes to be ok with minitest-line plugin

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -121,6 +121,9 @@ module Minitest
     self.load_plugins
 
     options = process_args args
+    if file = args.find {|arg| File.file?(arg)}
+      options.merge!(file: file)
+    end
 
     reporter = CompositeReporter.new
     reporter << SummaryReporter.new(options[:io], options)

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -291,7 +291,7 @@ module Minitest
 
     def self.run reporter, options = {}
       filter = options[:filter] || "/./"
-      filter = Regexp.new $1 if filter =~ %r%/(.*)/%
+      filter = Regexp.new $1 if filter =~ %r%^\s*/(.*)/\s*$%
 
       filtered_methods = self.runnable_methods.find_all { |m|
         filter === m || filter === "#{self}##{m}"

--- a/minitest.gemspec
+++ b/minitest.gemspec
@@ -1,0 +1,9 @@
+Gem::Specification.new "minitest", "5.10.1" do |s|
+  s.description = s.summary  = "Complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking"
+  s.email    = "shemusok@gmail.com"
+  s.homepage = "https://github.com/shemusok/minitest-line"
+  s.authors  = ['Magnus Holm']
+  s.license  = "MIT"
+  s.files    = Dir['lib/**/*.rb']
+  s.required_ruby_version = '>= 2.0.0'
+end

--- a/minitest.gemspec
+++ b/minitest.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new "minitest", "5.10.1" do |s|
   s.description = s.summary  = "Complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking"
-  s.email    = "shemusok@gmail.com"
-  s.homepage = "https://github.com/shemusok/minitest-line"
-  s.authors  = ['Magnus Holm']
+  s.email    = "ryand-ruby@zenspider.com"
+  s.homepage = "https://github.com/seattlerb/minitest"
+  s.authors  = ['Ryan Davis']
   s.license  = "MIT"
   s.files    = Dir['lib/**/*.rb']
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
1. I've found, that minitest-line plugin is not OK with minitest, if launched through spring binstub as:
`./bin/rake test test/some_test.rb -l 42`
because plugin can't recognize test file name.
So this fixed with additional option :file 124 line.

2. I've found, that test with '/' in 'describe' part is not OK with regexp in 297 line,
so I've changed it to match only if slashes are first and last symbols.

3. During testing I've found that it's impossible to use minitest right from github, so I've created gemspec file.

So, now launching single test given by line number is OK (with corresponding [fixes in minitest-line plugin](https://github.com/judofyr/minitest-line/pull/14)) with three popular launching commands:
`./bin/rake test test/some_test.rb -l 42`
`rake test test/some_test.rb -l 42`
`ruby -Itest test/some_test.rb -l 42`

@zenspider review pls! :)