### PR TITLE
Starting Travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.bundle
+/Gemfile.lock
+/pkg
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: ruby
+# To use rbx environment.
+dist: trusty
+sudo: false
+before_install:
+  # For jruby-head environment.
+  - which bundle || gem install bundler
+script:
+  - bundle exec rake test
+rvm:
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+  - jruby-9.1.8.0
+  - jruby-head
+  - rbx-3
+gemfile:
+  - Gemfile
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+    - rvm: rbx-3
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'rake'
+gem "hoe"


### PR DESCRIPTION
I prepared the files to start Travis test for `minitest`.
I think that testing several kind of Rubies on Travis regularly on Travis is useful.

I have checked it on my below local environment.

```
$ which ruby
/usr/local/ruby-2.4.1/bin/ruby

$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ which bundle
/usr/local/ruby-2.4.1/bin/bundle

$ bundle -v
Bundler version 1.14.6

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * bundler (1.14.6)
  * hoe (3.16.0)
  * rake (12.0.0)

$ bundle exec rake -T
rake announce              # publish   # Announce your release
rake audit                 # test      # Run ZenTest against the package
...
rake test                  # test      # Run the test suite
rake test:slow             # test      # Show bottom 25 tests wrt time
rake test_cmd              # test      # Print out the test command
rake test_deps             # test      # Show which test files fail when run alone

$ bundle exec rake test
...
312 runs, 910 assertions, 0 failures, 0 errors, 0 skips
```

Is it possible to merge this PR?

After you will enable the setting of https://travis-ci.org/seattlerb/minitest , we can start testing on Travis.

Thank you.
