### PR TITLE
Add circle.yml for circleci version 1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  ruby:
+    version: 2.4.1
+dependencies:
+  post:
+    - gem install hoe hoe-seattlerb isolate


### PR DESCRIPTION
I added `circle.yml`.

Because I guess that adding the file is better than current situation. It is obvious, other people can see the settings.

I guess that your current settings from Circle CI Web UI are

- Dependencies: `gem install hoe hoe-seattlerb isolate`
- Specifying Ruby version as `ruby-1.9.3-p448`.

So, I basically followed the settings.
But maybe latest version Ruby 2.4.1 is better than Ruby 1.9.3.

The test was success for my CircleCI environment.
https://circleci.com/gh/junaruga/minitest/6


Ideally I want matrix test on several Rubies such as Ruby 1.9.3, 2.0.0, 2.1, 2,2, 2.3.4, 2.4.1, ruby-head.

Right now CircleCI (version 1) does not support the matrix test, but version 2 beta supports it.
So, if you like the version 2 for `minitest`, I want to try the version 2 as next step. [1]

> https://circleci.com/docs/1.0/parallel-manual-setup/
> Build matrix support
> CircleCI 1.0 does not have native support for build matrices. However, there is a community project not maintained by CircleCI called circleci-matrix which can be used to produce build matrix behaviour on CircleCI. Please see their documentation for more details. Note that in CircleCI 2.0 you can use parallel jobs to accomplish build matrix behaviors.

How do you think?

Thanks.

[1] CircleCI version 2 beta: https://circleci.com/beta-access/
