### PR TITLE
Handle empty backtrace from external filter

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -231,7 +231,9 @@ module Minitest
   end
 
   def self.filter_backtrace bt # :nodoc:
-    backtrace_filter.filter bt
+    new_bt = backtrace_filter.filter bt
+    new_bt = bt.dup if new_bt.empty?
+    new_bt
   end
 
   ##
@@ -818,7 +820,6 @@ module Minitest
 
       new_bt = bt.take_while { |line| line !~ mt_re }
       new_bt = bt.select     { |line| line !~ mt_re } if new_bt.empty?
-      new_bt = bt.dup                                 if new_bt.empty?
 
       new_bt
     end


### PR DESCRIPTION
In the wild the backtrace_filter can be set by external filter (Rails do
it for their silencer). This can lead to the case there the external
backtrace_filer returns empty array. Other parts of minitest count on
the fact that there will still be something in the backtrace to use, and
can lead to issues such as "undefined method `split' for nil:NilClass"
when producing deprecation warnings.

Since we already had the logic to use all the backtrace when filtering
too much, I've moved this logic to be used also for external filters.