### PR TITLE
Add config.yml for circleci version 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ruby:2.4.1
+    working_directory: /home/ubuntu/minitest
+    steps:
+      - checkout
+      - run: gem install hoe hoe-seattlerb isolate
+      - run: |
+          ruby -e 'puts "External Encoding: #{Encoding.default_external}"'
+          RUBYOPT='-E utf-8' rake test


### PR DESCRIPTION
I prepared the files to start the test on clrcleci version2, seeing the document [1].

I tried to run matrix test. But unfortunately I knew maybe that we need to pay money if we will do matrix test for Rubies. That means 1st container is free. more than 2nd containers is not free. [2]

> Our pricing is flexible and scales with you. Add as many containers as you want for $50/month each.


This PR is for circleci version 2.0. it might better than circleci version 1's PR (https://github.com/seattlerb/minitest/pull/694).

My test result is here [3]

[1] https://circleci.com/docs/2.0
[2] maybe this page: https://circleci.com/gh/organizations/seattlerb/settings#linux-pricing
[3] https://circleci.com/gh/junaruga/minitest/14
