### PR TITLE
Spec marshal

### DIFF
--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -774,6 +774,24 @@ class TestMinitestRunnable < Minitest::Test
 
     assert_marshal %w[@NAME @assertions @failures]
   end
+
+  def test_spec_marshal
+    klass = describe("whatever") { it("passes") { assert true } }
+    rm = klass.runnable_methods.first
+
+    # Run the test
+    @tc = klass.new(rm).run
+
+    # Pass it over the wire
+    over_the_wire = Marshal.load(Marshal.dump(@tc))
+
+    assert_equal @tc.time, over_the_wire.time
+    assert_equal @tc.name, over_the_wire.name
+    assert_equal @tc.assertions, over_the_wire.assertions
+    assert_equal @tc.failures, over_the_wire.failures
+    assert_equal @tc.class.name, over_the_wire.class.name
+    assert_equal @tc.class.desc, over_the_wire.class.desc
+  end
 end
 
 class TestMinitestTest < TestMinitestRunnable


### PR DESCRIPTION
This is a test case showing that instances of spec style tests can't be
marshaled due to their anonymous class.  This is problematic for
distributed tests as test information is stored on the instance of the
test object.

Our current solution at work is to copy all the information from the test in to a value object that we send across the wire.  Another problem is that the minitest reporters that are on the other side of the wire have certain expectations about the object passed to them: namely that the object is actually an instance of the test.  The reporter uses the class of the "test instance" for reporting, so we have to do weird stuff to fake out the reporter.

I've added a possible fix in 1e353c63b147907424a12cb0ca46ce5269721990 that is similar to what we're doing in our test suite.  It feels like the default implementation of `run` shouldn't return the test instance, but a concrete read-only value object that contains test run information instead.  Then we could eliminate the `marshal_dump` / load methods on the Test class.