### PR TITLE
Add FAQ example for setup before all tests

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -434,6 +434,21 @@ you want to extend your test using setup/teardown via a module, just
 make sure you ALWAYS call super. before/after automatically call super
 for you, so make sure you don't do it twice.
 
+=== How to run code before a group of tests?
+
+Use a constant with begin...end like this:
+
+  describe Blah do
+    SETUP = begin
+       # ... this runs once when describe Blah starts
+    end
+    # ...
+  end
+
+This can be useful for expensive initializations or sharing state.
+Remember, this is just ruby code, so you need to make sure this 
+technique and sharing state doesn't interfere with your tests.
+
 === Why am I seeing <tt>uninitialized constant MiniTest::Test (NameError)</tt>?
 
 Are you running the test with Bundler (e.g. via <tt>bundle exec</tt> )? If so, 


### PR DESCRIPTION
I searched for a way to accomplish this, and found some blog posts about using a class variable such as @@foo = begin...end. 

When I tried using a class variable, `rake spec` reports "warning: class variable access from toplevel". 

When I tried a constant, `rake spec` succeeds without any warnings.

This setup approach has sped up some of my tests by 80%, because of database seeding and also because of data that's fetched across the internet.