### PR TITLE
Location does not always returns the class name

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -85,6 +85,7 @@ module Minitest
     # Runs a single test with setup/teardown hooks.
 
     def run
+      self.klass = self.class
       with_info_handler do
         time_it do
           capture_exceptions do

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -811,6 +811,10 @@ class TestMinitestTest < TestMinitestRunnable
       assert_in_epsilon 3.14, new_tc.time
     end
   end
+
+  def test_location
+    assert_equal "TestMinitestTest#test_location", location
+  end
 end
 
 class TestMinitestUnitTestCase < Minitest::Test


### PR DESCRIPTION
When I call `location` from a test, it simply returns `#method` instead of `Class#method`. However it used to work properly in 5.10.3.

```ruby
require "minitest/autorun"

class FooTest < Minitest::Test
  def test_bar
    assert_equal("FooTest#test_bar", location)
  end
end
```

```
$ ruby test_foo.rb
  1) Failure:
FooTest#test_bar [foo_test.rb:5]:
--- expected
+++ actual
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-"FooTest#test_bar"
+"#test_bar"
```