### PR TITLE
add --quiet flag

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -287,6 +287,7 @@ provided via plugins. To see them, simply run with +--help+:
         -h, --help                       Display this help.
         -s, --seed SEED                  Sets random seed. Also via env. Eg: SEED=n rake
         -v, --verbose                    Verbose. Show progress processing files.
+        -q, --quiet                      Quiet. Show minimal output.
         -n, --name PATTERN               Filter run on /regexp/ or string.
         -e, --exclude PATTERN            Exclude /regexp/ or string from run.
 

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -186,6 +186,10 @@ module Minitest
         options[:verbose] = true
       end
 
+      opts.on "-q", "--quiet", "Quiet. Show minimal output." do
+        options[:quiet] = true
+      end
+
       opts.on "-n", "--name PATTERN", "Filter run on /regexp/ or string." do |a|
         options[:filter] = a
       end
@@ -698,10 +702,10 @@ module Minitest
     def start # :nodoc:
       super
 
-      io.puts "Run options: #{options[:args]}"
-      io.puts
-      io.puts "# Running:"
-      io.puts
+      io.puts "Run options: #{options[:args]}" unless options[:quiet]
+      io.puts unless options[:quiet]
+      io.puts "# Running:" unless options[:quiet]
+      io.puts unless options[:quiet]
 
       self.sync = io.respond_to? :"sync=" # stupid emacs
       self.old_sync, io.sync = io.sync, true if self.sync
@@ -712,11 +716,11 @@ module Minitest
 
       io.sync = self.old_sync
 
-      io.puts unless options[:verbose] # finish the dots
-      io.puts
-      io.puts statistics
+      io.puts unless options[:verbose] || options[:quiet] # finish the dots
+      io.puts unless options[:quiet]
+      io.puts statistics  unless options[:quiet]
       aggregated_results io
-      io.puts summary
+      io.puts summary  unless options[:quiet]
     end
 
     def statistics # :nodoc:


### PR DESCRIPTION
This patch adds a command line flag ("-q" or "--quiet") to suppress all output other than the single character pass/fail/skip result.

This address issue #616 
