### PR TITLE
Print '--seed=1234' rather than '--seed 1234' by default

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -220,7 +220,7 @@ module Minitest
     unless options[:seed] then
       srand
       options[:seed] = (ENV["SEED"] || srand).to_i % 0xFFFF
-      orig_args << "--seed" << options[:seed].to_s
+      orig_args << "--seed=#{options[:seed]}"
     end
 
     srand options[:seed]


### PR DESCRIPTION
before:
    Run options: --seed 62153
after:
    Run options: --seed=10759

This is friendlier to passing options via Rake.  These forms work:
    env TESTOPTS='--seed=1234' rake test
    rake test TESTOPTS='--seed=1234'
These forms with a space fail for me:
    env TESTOPTS='--seed 1234' rake test
    rake test TESTOPTS='--seed 1234'
with message like:
    File does not exist: /home/me/kubeclient/1234

Of course this assumes one even discovers the rake `TESTOPTS` var...
Still, one less obstacle :-)

(I see from #564 you're not interested in minitest directly telling user Rake-specific hints how to use `TESTOPTS`.
Consider perhaps printing `SEED=1234` hint instead of `--seed` hint?  This works when running minitest directly, through Rake and probably through other runners.)