### PR TITLE
Correctly unescape newlines in diffs

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -125,7 +125,7 @@ module Minitest
     # uses mu_pp to do the first pass and then cleans it up.
 
     def mu_pp_for_diff obj
-      mu_pp(obj).gsub(/\\n/, "\n").gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
+      mu_pp(obj).gsub(/\\./) { |m| m == '\n' ? "\n" : m }.gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
     end
 
     ##

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1055,6 +1055,21 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_equal_unescape_newlines
+    msg = <<-EOM.gsub(/^ {10}/, "")
+          --- expected
+          +++ actual
+          @@ -1,2 +1 @@
+          -"hello
+          -world"
+          +"hello\\\\nworld"
+          EOM
+
+    assert_triggered msg do
+      @tc.assert_equal "hello\nworld", 'hello\nworld'
+    end
+  end
+
   def test_assert_equal_does_not_allow_lhs_nil
     if Minitest::VERSION =~ /^6/ then
       warn "Time to strip the MT5 test"


### PR DESCRIPTION
@carolineschnapp noticed that, if the code under test mistakenly uses a single-quoted string rather than a double-quoted one, the diff shown by `assert_equal` is unhelpful in the presence of newlines:

```
mistake = 'hello\nworld'
assert_equal "hello\nworld", mistake

Failure:
Test#test_assert_equal:
--- expected
+++ actual
@@ -1,2 +1,2 @@
-"hello
+"hello\
 world"
```

Whereas the expected diff would be:

```
Failure:
Test#test_assert_equal:
--- expected
+++ actual
@@ -1,2 +1 @@
-"hello
-world"
+"hello\\nworld"
```

This is happening because of indiscriminate unescaping of the character sequence “\n” in `mu_pp_for_diff`. In the case where the backslash is itself escaped, as in the string `"hello\\nworld"`, it represents a literal backslash and therefore should have no effect on the subsequent “n”.

In lieu of `String#undump` [1,2] being universally available to solve the more general problem, our best bet is to use a more permissive pattern in `String#gsub` to only pick out escape sequences which aren’t already part of another escape sequence, then replace those sequences if they happen to represent a newline.

[1] https://github.com/ruby/ruby/commit/bbec11d329f5a72fe6151ec9fb0e25ff255f2eed
[2] https://github.com/tadd/string_undump