### PR TITLE
Taking out global expectations from README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -126,13 +126,13 @@ Define your tests as methods beginning with +test_+.
 
     describe "when asked about cheeseburgers" do
       it "must respond positively" do
-        @meme.i_can_has_cheezburger?.must_equal "OHAI!"
+        expect(@meme.i_can_has_cheezburger?).must_equal "OHAI!"
       end
     end
 
     describe "when asked about blending possibilities" do
       it "won't say no" do
-        @meme.will_it_blend?.wont_match /^no/i
+        expect(@meme.will_it_blend?).wont_match /^no/i
       end
     end
   end
@@ -379,7 +379,7 @@ The following implementation and test:
       end
 
       it "must respond to work" do
-        @worker.must_respond_to :work
+        expect(@worker).must_respond_to :work
       end
     end
 


### PR DESCRIPTION
I just think if global expectations are being depreciated, it should be removed from the project README.

Very minor suggested change