### PR TITLE
Allow nil on the left-hand side of assert_equal IF explicit

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -169,11 +169,18 @@ module Minitest
     #
     # See also: Minitest::Assertions.diff
 
-    def assert_equal exp, act, msg = nil
+    def assert_equal exp, act, msg_or_opts = nil, opts = {}
+      if Hash === msg_or_opts then
+        msg = nil
+        opts = msg_or_opts
+      else
+        msg = msg_or_opts
+      end
+
       msg = message(msg, E) { diff exp, act }
       result = assert exp == act, msg
 
-      if nil == exp then
+      if nil == exp && !opts[:allow_nil] then
         if Minitest::VERSION =~ /^6/ then
           refute_nil exp, "Use assert_nil if expecting nil."
         else

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1073,6 +1073,19 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_equal_does_allow_lhs_nil_if_explicitly_requested
+    assert_output "", "" do
+      @tc.assert_equal nil, nil, allow_nil: true
+    end
+  end
+
+  def test_assert_with_explicit_lhs_nil_supports_a_custom_message
+    msg = "message.\nExpected: nil\n  Actual: \"blah\""
+    assert_triggered msg do
+      @tc.assert_equal nil, "blah", "message", allow_nil: true
+    end
+  end
+
   def test_assert_equal_does_not_allow_lhs_nil_triggered
     assert_triggered "Expected: nil\n  Actual: false" do
       @tc.assert_equal nil, false


### PR DESCRIPTION
The caller must pass the `allow_nil: true` option or else (starting with Minitest 6), the assertion will fail if a LHS `nil` value is encountered.

## :warning: Warning… ☠️🐴 alert!

 I know that this topic has been [discussed at length](https://github.com/seattlerb/minitest/issues/666), but I'm new to the conversation and noticed that one idea that hadn't come up (at least that I'd seen) was to allow for an _explicit_ opt-in to the otherwise dangerous LHS `nil` behavior.

This would allow a developer to extend Minitest with equality assertion helpers, but without the `nil` value check conditionals. In cases where the developer certainly wants this behavior, it's available. In typical usage, safe practices are encouraged/enforced.

I don't have a :dog: in the fight so I'm still happy whether this is merged or closed. Mostly, I'd never contributed to Minitest and wanted to. :smile: I tried to mimic the code style and hope I did it justice!

I do hope that this change might be a reasonable middle ground solution! Thank you for your ongoing and great work on Minitest! 🏆💐