### PR TITLE
Add mutant-minitest to known integrations section.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -664,6 +664,7 @@ minitest_owrapper           :: Get tests results as a TestResult object.
 minitest_should             :: Shoulda style syntax for minitest test::unit.
 minitest_tu_shim            :: Bridges between test/unit and minitest.
 mongoid-minitest            :: Minitest matchers for Mongoid.
+mutant-minitest             :: Minitest integration for mutant.
 pry-rescue                  :: A pry plugin w/ minitest support. See
                                pry-rescue/minitest.rb.
 rspec2minitest              :: Easily translate any RSpec matchers to Minitest


### PR DESCRIPTION
I do not know its its desired to link to the gems / docs. I intentionally left these out, to mirror the way the others are presented.