### PR TITLE
Check `filter` klass before match

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -301,7 +301,7 @@ module Minitest
 
     def self.run reporter, options = {}
       filter = options[:filter] || "/./"
-      filter = Regexp.new $1 if filter =~ %r%/(.*)/%
+      filter = Regexp.new $1 if filter.is_a?(String) && filter =~ %r%/(.*)/%
 
       filtered_methods = self.runnable_methods.find_all { |m|
         filter === m || filter === "#{self}##{m}"


### PR DESCRIPTION
`Object#=~` was deprecated in Ruby 2.6.
Ref: https://bugs.ruby-lang.org/issues/15231

Since `filter` assumes `String`, there is no influence if are using only minitest.

But some plugins customize filter. For example, Rails has a customized filter to filter by line.
As a result, shows deprecation message when run test with Ruby 2.6 + Rails.

```
/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/minitest-5.11.3/lib/minitest.rb:304: warning: deprecated Object#=~ is called on Rails::TestUnit::CompositeFilter; it always returns nil
```

This may occur in other plugins. So I think good to fixes inside minitest.

Thanks!