### PR TITLE
Kind error message for missing block

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -291,6 +291,8 @@ module Minitest
     # See also: #assert_silent
 
     def assert_output stdout = nil, stderr = nil
+      flunk "assert_output captures message from given block. Provide a block to use it." unless block_given?
+
       out, err = capture_io do
         yield
       end
@@ -327,6 +329,8 @@ module Minitest
     # passed.
 
     def assert_raises *exp
+      flunk "assert_raises captures errors from given block. Provide a block to use it." unless block_given?
+
       msg = "#{exp.pop}.\n" if String === exp.last
       exp << StandardError if exp.empty?
 

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1345,6 +1345,12 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_output_without_block
+    assert_triggered "assert_output captures message from given block. Provide a block to use it." do
+      @tc.assert_output "blah"
+    end
+  end
+
   def test_assert_output_triggered_both
     assert_triggered util_msg("blah", "blah blah", "In stderr") do
       @tc.assert_output "yay", "blah" do
@@ -1417,6 +1423,12 @@ class TestMinitestUnitTestCase < Minitest::Test
   def test_assert_raises_module
     @tc.assert_raises MyModule do
       raise AnError
+    end
+  end
+
+  def test_assert_raises_without_block
+    assert_triggered "assert_raises captures errors from given block. Provide a block to use it." do
+      @tc.assert_raises StandardError
     end
   end
 


### PR DESCRIPTION
`assert_output` and `assert_raises` requires a block to work.
Currently, without block, it fails with `LocalJumpError`,which is not helpful.
Those assertions now fail with kind error message without a block.

If you found the message awkward, please modify it.