### PR TITLE
Refactor self.need_to_diff?

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -44,6 +44,19 @@ module Minitest
     end
 
     ##
+    # Returns whether need to diff.
+    def self.need_to_diff? expect, butwas
+          (expect.include?("\n")    ||
+              butwas.include?("\n")    ||
+              expect.size > 30         ||
+              butwas.size > 30         ||
+              expect == butwas)        &&
+              Minitest::Assertions.diff
+
+
+    end
+
+    ##
     # Set the diff command to use in #diff.
 
     def self.diff= o
@@ -61,16 +74,8 @@ module Minitest
       butwas = mu_pp_for_diff act
       result = nil
 
-      need_to_diff =
-        (expect.include?("\n")    ||
-         butwas.include?("\n")    ||
-         expect.size > 30         ||
-         butwas.size > 30         ||
-         expect == butwas)        &&
-        Minitest::Assertions.diff
-
       return "Expected: #{mu_pp exp}\n  Actual: #{mu_pp act}" unless
-        need_to_diff
+        Minitest::Assertions.need_to_diff? expect, butwas
 
       Tempfile.open("expect") do |a|
         a.puts expect


### PR DESCRIPTION
The code for whether need to diff can (and does) behave differently on different platforms.

In my testing, I need to know whether a failed assertion will diff, because the 'actual' value will vary accordingly.  Therefore I'm proposing to expose the logic as a new method, self.need_to_diff?

Minitest's own tests, before and after this change, pass on my Linux box.