### PR TITLE
Allow Minitest::Spec classes to be marshalled

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -268,6 +268,14 @@ class Minitest::Spec < Minitest::Test
         nuke_test_methods!
       end
 
+      cls_const = const_base = "Test__#{name.to_s.gsub(/\W/, '')}"
+      uniq_id = 2
+      while const_defined? cls_const
+        cls_const = const_base + uniq_id.to_s
+        uniq_id += 1
+      end
+      Minitest::Spec.const_set(cls_const, cls)
+
       children << cls
 
       cls

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -790,14 +790,17 @@ class TestMinitestRunnable < Minitest::Test
 
   def test_spec_marshal
     klass = describe("whatever") { it("passes") { assert true } }
-    rm = klass.runnable_methods.first
+
+    # Pass the test over the wire
+    remote_klass = Marshal.load Marshal.dump klass
 
     # Run the test
+    rm = remote_klass.runnable_methods.first
     @tc = klass.new(rm).run
 
     assert_kind_of Minitest::Result, @tc
 
-    # Pass it over the wire
+    # Pass the result back over the wire
     over_the_wire = Marshal.load Marshal.dump @tc
 
     assert_equal @tc.time,       over_the_wire.time


### PR DESCRIPTION
Possible fix for https://github.com/seattlerb/minitest/issues/794

## Why
This PR takes the basic idea from https://github.com/blowmage/minitest-rails/pull/218 and applies it upstream to minitest. I think this problem is not necessarily specific to rails - it would be a problem with any parallel executor that uses DRb to synchronize parallel test runs across multiple processes. It feels like the fix belongs in minitest itself (since fixing it elsewhere requires monkey-patching minitest). Fixing it upstream also allows other gems like [minitest-spec-rails](https://github.com/metaskills/minitest-spec-rails) to take advantage of it.

## How
This change defines a unique constant for every spec class which will
allow them to be marshalled/unmarshalled and sent over the wire with DRb.

