### PR TITLE
support new Proc#to_s format

### DIFF
--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -26,9 +26,8 @@ describe Minitest::Spec do
 
     msg = e.message.sub(/(---Backtrace---).*/m, '\1')
     msg.gsub!(/\(oid=[-0-9]+\)/, "(oid=N)")
-    msg.gsub!(/@.+>/, "@PATH>")
     msg.gsub!(/(\d\.\d{6})\d+/, '\1xxx') # normalize: ruby version, impl, platform
-    msg.gsub!(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
+    msg.gsub!(/:0x[Xa-fA-F0-9]{4,}[ @].+?>/, ":0xXXXXXX@PATH>")
 
     if expected
       @assertion_count += 1
@@ -213,7 +212,7 @@ describe Minitest::Spec do
       _(6 * 9).must_equal 42, "msg"
     end
 
-    assert_triggered(/^-42\n\+#<Proc:0xXXXXXX@PATH>\n/) do
+    assert_triggered(/^-42\n\+#<Proc:0xXXXXXX[ @]PATH>\n/) do
       _(proc { 42 }).must_equal 42 # proc isn't called, so expectation fails
     end
   end


### PR DESCRIPTION
We are discussing to change `Proc#to_s` notation from
  `#<Proc:0xXXXX@t.rb:2>`
to
  `#<Proc:0xXXXX t.rb:2>`
at https://bugs.ruby-lang.org/issues/16101

and minitest's test depends on this behavior.

This PR support both `@` or ` ` separation to path tests.
Comments for [Feature #16101] is also welcome.