### PR TITLE
Tweak multithreading section of README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -220,9 +220,9 @@ verification to ensure they got all the calls they were expecting."
     end
   end
 
-**Multi-threading and Mocks**
+==== Multi-threading and Mocks
 
-Minitest mocks do not support multi-threading if it works, fine, if it doesn't
+Minitest mocks do not support multi-threading. If it works, fine, if it doesn't
 you can use regular ruby patterns and facilities like local variables. Here's
 an example of asserting that code inside a thread is run:
 


### PR DESCRIPTION
Two small tweaks to the README that I came across when reading it:

- Fixed header using which (I presume) was using markdown style rather than rdoc.
- Split out two sentences that didn't read easily when merged into one.