### PR TITLE
Mention minitest-global_expectations in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -601,6 +601,7 @@ minitest-firemock           :: Makes your Minitest mocks more resilient.
 minitest-focus              :: Focus on one test at a time.
 minitest-gcstats            :: A minitest plugin that adds a report of the top
                                tests by number of objects allocated.
+minitest-global_expectations:: Support minitest expectation methods for all objects
 minitest-great_expectations :: Generally useful additions to minitest's
                                assertions and expectations.
 minitest-growl              :: Test notifier for minitest via growl.


### PR DESCRIPTION
This library allows for backwards compatibility with older versions
of minitest, so you can continue to do `foo.must_equal 1` instead of
`_(foo).must_equal 1`.