### PR TITLE
Avoid using `match?` for supports old rubies

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -136,8 +136,8 @@ module Minitest
       str = mu_pp obj
 
       # both '\n' & '\\n' (_after_ mu_pp (aka inspect))
-      single = str.match?(/(?<!\\|^)\\n/)
-      double = str.match?(/(?<=\\|^)\\n/)
+      single = !!str.match(/(?<!\\|^)\\n/)
+      double = !!str.match(/(?<=\\|^)\\n/)
 
       process =
         if single ^ double then


### PR DESCRIPTION
This is breaking some libraries CI that supports old rubies (e.g. [Rails](https://buildkite.com/rails/rails/builds/63928#194ec831-37f0-4bc6-b702-c7965bdd061b/957-972)).