### PR TITLE
Only perform Minitest.autorun at_exits in initial process

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -50,12 +50,15 @@ module Minitest
   # Registers Minitest to run at process exit
 
   def self.autorun
+    initial_pid = Process.pid
     at_exit {
+      next if Process.pid != initial_pid
       next if $! and not ($!.kind_of? SystemExit and $!.success?)
 
       exit_code = nil
 
       at_exit {
+        next if Process.pid != initial_pid
         @@after_run.reverse_each(&:call)
         exit exit_code || false
       }

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -2198,4 +2198,16 @@ class TestMinitestUnitRecording < MetaMetaMetaTestCase
       end
     end
   end
+
+  def test_fork_can_exit_cleanly
+    pid = fork {}
+    _, status = Process.waitpid2(pid)
+    assert_equal 0, status.exitstatus
+  end
+
+  def test_fork_can_exit_with_code
+    pid = fork { exit(123) }
+    _, status = Process.waitpid2(pid)
+    assert_equal 123, status.exitstatus
+  end
 end


### PR DESCRIPTION
It can be useful to `fork` within tests. We also use forking in Rails' test suite for test parallelization with process isolation.

Previously, when forking `Minitest.autorun`'s `at_exit` blocks would still be called, would run the after_run callbacks, and would change the exit status to 1.

This could be worked around using `Process.exit!` or often one could just ignore the status code of `fork`, but ideally forks could exit normally. I can't think of a case we'd want to run this code from a fork.

This commit changes `Minitest.autorun` to record the pid when it is called, and only runs the at_exit code in that process. I've added two (previously failing) tests to check we can exit with clean status codes.