### PR TITLE
Implicitly assert nothing is raised inside block based assertions

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -905,24 +905,20 @@ module Minitest
   # Assertion wrapping an unexpected error that was raised during a run.
 
   class UnexpectedError < Assertion
-    attr_accessor :exception # :nodoc:
+    attr_accessor :error # :nodoc:
 
-    def initialize exception # :nodoc:
+    def initialize error # :nodoc:
       super "Unexpected exception"
-      self.exception = exception
+      self.error = error
     end
 
     def backtrace # :nodoc:
-      self.exception.backtrace
-    end
-
-    def error # :nodoc:
-      self.exception
+      self.error.backtrace
     end
 
     def message # :nodoc:
       bt = Minitest.filter_backtrace(self.backtrace).join "\n    "
-      "#{self.exception.class}: #{self.exception.message}\n    #{bt}"
+      "#{self.error.class}: #{self.error.message}\n    #{bt}"
     end
 
     def result_label # :nodoc:

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -609,6 +609,20 @@ class TestMinitestAssertions < Minitest::Test
     end
   end
 
+  def test_assert_output_unexpected_error
+    assertion = @tc.assert_raises Minitest::UnexpectedError do
+      @tc.assert_raises ArgumentError do
+        @tc.assert_output "yay" do
+          print "nay"
+          1 + '2'
+        end
+      end
+    end
+
+    assert_instance_of Minitest::UnexpectedError, assertion
+    assert_instance_of TypeError, assertion.error
+  end
+
   def test_assert_predicate
     @tc.assert_predicate "", :empty?
   end
@@ -875,11 +889,13 @@ class TestMinitestAssertions < Minitest::Test
   end
 
   def test_assert_throws_argument_exception
-    @tc.assert_raises ArgumentError do
+    assertion = @tc.assert_raises Minitest::UnexpectedError do
       @tc.assert_throws :blah do
         raise ArgumentError
       end
     end
+
+    assert_instance_of ArgumentError, assertion.error
   end
 
   def test_assert_throws_different
@@ -891,11 +907,13 @@ class TestMinitestAssertions < Minitest::Test
   end
 
   def test_assert_throws_name_error
-    @tc.assert_raises NameError do
+    assertion = @tc.assert_raises Minitest::UnexpectedError do
       @tc.assert_throws :blah do
         raise NameError
       end
     end
+
+    assert_instance_of NameError, assertion.error
   end
 
   def test_assert_throws_unthrown
@@ -904,6 +922,20 @@ class TestMinitestAssertions < Minitest::Test
         # do nothing
       end
     end
+  end
+
+  def test_assert_throws_unexpected_error
+    assertion = @tc.assert_raises Minitest::UnexpectedError do
+      @tc.assert_raises TypeError do
+        @tc.assert_throws :blah do
+          1 + '2'
+          throw :not_blah
+        end
+      end
+    end
+
+    assert_instance_of Minitest::UnexpectedError, assertion
+    assert_instance_of TypeError, assertion.error
   end
 
   def test_capture_io


### PR DESCRIPTION
A somewhat common mistake is to entirely skip a block based assertion
because of an improper use of `assert_raises`, e.g.

```ruby
assert_raises TypeError do
  assert_output "yay" do
    print "nay"
    raise TypeError
  end
end
```

In this snippet `assert_output` is totally skipped but the test passes.

Of course it should be rewritten as:

```ruby
assert_output "yay" do
  assert_raises TypeError do
    print "nay"
    raise TypeError
  end
end
```

But it's fairly easy to overlook this mistake.

What this change does, is that it immediately cast unexpected errors into `Minitest::UnexpectedError`.

cc @kaspth @rafaelfranca @wvanbergen @dylanahsmith