### PR TITLE
use explicit Warning module

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -10,7 +10,7 @@ class Module # :nodoc:
       def #{new_name} *args
         where = Minitest.filter_backtrace(caller).first
         where = where.split(/:in /, 2).first # clean up noise
-        Warning.warn "DEPRECATED: global use of #{new_name} from #\{where}. Use _(obj).#{new_name} instead. This will fail in Minitest 6."
+        Kernel.warn "DEPRECATED: global use of #{new_name} from #\{where}. Use _(obj).#{new_name} instead. This will fail in Minitest 6."
         Minitest::Expectation.new(self, Minitest::Spec.current).#{new_name}(*args)
       end
     EOM

--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -10,7 +10,7 @@ class Module # :nodoc:
       def #{new_name} *args
         where = Minitest.filter_backtrace(caller).first
         where = where.split(/:in /, 2).first # clean up noise
-        warn "DEPRECATED: global use of #{new_name} from #\{where}. Use _(obj).#{new_name} instead. This will fail in Minitest 6."
+        Warning.warn "DEPRECATED: global use of #{new_name} from #\{where}. Use _(obj).#{new_name} instead. This will fail in Minitest 6."
         Minitest::Expectation.new(self, Minitest::Spec.current).#{new_name}(*args)
       end
     EOM


### PR DESCRIPTION
if an object has its own warn method, Deprecation warnings may have unexpected results.

An old legacy class of mine has warn defined and it accepts 0 arguments. This deprecation warning results in: ArgumentError: wrong number of arguments. Also, the actual depecration warning is not printed, so the results are, confusing to say the least.

