### PR TITLE
If a callable mock includes kwargs, Ruby 2.7 warns

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -230,6 +230,7 @@ class Object
         val_or_callable
       end
     end
+    metaclass.send(:ruby2_keywords, name) if metaclass.respond_to?(:ruby2_keywords, true)
 
     yield self
   ensure

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -766,6 +766,17 @@ class TestMinitestStub < Minitest::Test
     end
   end
 
+  def test_stub_value_kwargs
+    stub = ->(foo, bar:) { foo + bar }
+
+    assert_silent do
+      Thread.stub :new, stub do
+        result = Thread.new(1, bar: 2)
+        @tc.assert_equal 3, result
+      end
+    end
+  end
+
   def test_stub_value_block_5
     @assertion_count += 1
     Thread.stub5 :new, 42 do


### PR DESCRIPTION
This commit explicitly forwards kwargs to remove the warning, and adds a test to assert that it was silent.