### PR TITLE
Add helpful section upgrading to MT6

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -376,6 +376,34 @@ Using our example above, here is how we might implement MyCI:
 
 == FAQ
 
+== Easing the transition to Minitest 6
+
+Minitest has started issuing _DEPRECATED_ warn messages if you are using the global version of expectations.
+You might come across a similar warning such as:
+
+```
+DEPRECATED: global use of must_equal from ... Use _(obj).must_equal instead. This will fail in Minitest 6…
+```
+
+If you'd like to easily transition your codebase consider leveraging https://github.com/jonatas/fast/
+You can simply include a _Fastfile_ in the source of your repository with the contents of:
+
+```ruby
+Fast.shortcut(:minitest_upgrade) do
+  # the file to upgrade
+  file_name = ARGV.last
+  raise "Missing file argument" unless File.file?(file_name)
+
+  puts "Doing Minitest 6 upgrade for #{file_name}"
+  Fast.rewrite_file('(send _ { :must_equal :must_be_empty :must_include :must_be :must_be_empty } _)', file_name) do | node|
+    expected_value = node.children[0].location.expression
+    replace(expected_value, "expect(#{expected_value.source})")
+  end
+end
+```
+
+You can execute this on individual files now to replace via: `fast .minitest_upgrade FILE`
+
 === How to test SimpleDelegates?
 
 The following implementation and test:

--- a/README.rdoc
+++ b/README.rdoc
@@ -404,6 +404,8 @@ end
 
 You can execute this on individual files now to replace via: `fast .minitest_upgrade FILE`
 
+> You will need to `gem install ffast`
+
 === How to test SimpleDelegates?
 
 The following implementation and test:


### PR DESCRIPTION
Add section explaining use of [ffast](https://github.com/jonatas/fast/) to help migrate code easily to the new expectation sequence.

I recently migrated our version of Minitest on a very large codebase and we've been hit with a **ton** of _DEPRECATED_ warnings.

Relying on AST transformation is a great way to easily migrate the codebase to use the new style.

There are even more advanced concepts in the _fast_ library such as "experiments"; which can run minitest following every change. The amount documented here should be a great starting point for others thought!