### PR TITLE
Add ability to silence warnings

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -224,7 +224,7 @@ module Minitest
           where = Minitest.filter_backtrace(caller).first
           where = where.split(/:in /, 2).first # clean up noise
 
-          warn "DEPRECATED: Use assert_nil if expecting nil from #{where}. This will fail in Minitest 6."
+          warn "DEPRECATED: Use assert_nil if expecting nil from #{where}. This will fail in Minitest 6." unless ENV["MT_SILENCE"]
         end
       end
 

--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -10,7 +10,7 @@ class Module # :nodoc:
       def #{new_name} *args
         where = Minitest.filter_backtrace(caller).first
         where = where.split(/:in /, 2).first # clean up noise
-        warn "DEPRECATED: global use of #{new_name} from #\{where}. Use _(obj).#{new_name} instead. This will fail in Minitest 6."
+        warn "DEPRECATED: global use of #{new_name} from #\{where}. Use _(obj).#{new_name} instead. This will fail in Minitest 6." unless ENV["MT_SILENCE"]
         Minitest::Expectation.new(self, Minitest::Spec.current).#{new_name}(*args)
       end
     EOM


### PR DESCRIPTION
Add an environment variable (_MT_SILENCE_) to silence the **DEPRECATED** warnings.

Although they are helpful, in a large codebase, they can pose a lot of noise for those that are not tasked with migrating the codebase. I am slowly migrating our codebase however our developers are frustrated with the number of warnings in by Minitest in the logs.

I would very much appreciate this happy medium.

fixes #829