### PR TITLE
Reseed RNG before each test

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -323,6 +323,7 @@ module Minitest
 
       with_info_handler reporter do
         filtered_methods.each do |method_name|
+          Random.srand options[:seed] if options[:seed]
           run_one_method self, method_name, reporter
         end
       end


### PR DESCRIPTION
This ensure that for a given `--seed` value, a test will always start from the same seed.

Otherwise previous tests using the RNG, would leak state.

This is something we had for a very long time as a global `setup`, I figured it made sense upstream.

A recent commit to ruby reminded me of it: https://github.com/ruby/ruby/commit/7c1553e91db07fed4fed3287b50304f1c69a685d