### PR TITLE
Return true on a successful refutal

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -628,7 +628,7 @@ module Minitest
 
     def refute test, msg = nil
       msg ||= message { "Expected #{mu_pp(test)} to not be truthy" }
-      not assert !test, msg
+      assert !test, msg
     end
 
     ##

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -1150,7 +1150,7 @@ class TestMinitestAssertions < Minitest::Test
   def test_refute
     @assertion_count = 2
 
-    @tc.assert_equal false, @tc.refute(false), "returns false on success"
+    @tc.assert_equal true, @tc.refute(false), "returns true on success"
   end
 
   def test_refute_empty

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -72,7 +72,7 @@ describe Minitest::Spec do
   it "needs to check for file non-existence" do
     @assertion_count = 3
 
-    _(_("blah").path_wont_exist).must_equal false
+    _(_("blah").path_wont_exist).must_equal true
 
     assert_triggered "Expected path '#{__FILE__}' to not exist." do
       _(__FILE__).path_wont_exist
@@ -96,7 +96,7 @@ describe Minitest::Spec do
   it "needs to be sensible about wont_include order" do
     @assertion_count += 3 # wont_include is 2 assertions
 
-    _(_([1, 2, 3]).wont_include(5)).must_equal false
+    _(_([1, 2, 3]).wont_include(5)).must_equal true
 
     assert_triggered "Expected [1, 2, 3] to not include 2." do
       _([1, 2, 3]).wont_include 2
@@ -195,7 +195,7 @@ describe Minitest::Spec do
   end
 
   it "needs to verify binary messages" do
-    _(_(42).wont_be(:<, 24)).must_equal false
+    _(_(42).wont_be(:<, 24)).must_equal true
 
     assert_triggered "Expected 24 to not be < 42." do
       _(24).wont_be :<, 42
@@ -256,7 +256,7 @@ describe Minitest::Spec do
   it "needs to verify floats outside a delta" do
     @assertion_count += 1 # extra test
 
-    _(_(24).wont_be_close_to(42)).must_equal false
+    _(_(24).wont_be_close_to(42)).must_equal true
 
     assert_triggered "Expected |42 - 42.0| (0.0) to not be <= 0.001." do
       _(6 * 7.0).wont_be_close_to 42
@@ -275,7 +275,7 @@ describe Minitest::Spec do
   it "needs to verify floats outside an epsilon" do
     @assertion_count += 1 # extra test
 
-    _(_(24).wont_be_within_epsilon(42)).must_equal false
+    _(_(24).wont_be_within_epsilon(42)).must_equal true
 
     x = "0.042"
     assert_triggered "Expected |42 - 42.0| (0.0) to not be <= #{x}." do
@@ -343,8 +343,8 @@ describe Minitest::Spec do
 
   it "needs to verify inequality" do
     @assertion_count += 2
-    _(_(42).wont_equal(6 * 9)).must_equal false
-    _(_(proc {}).wont_equal(42)).must_equal false
+    _(_(42).wont_equal(6 * 9)).must_equal true
+    _(_(proc {}).wont_equal(42)).must_equal true
 
     assert_triggered "Expected 1 to not be equal to 1." do
       _(1).wont_equal 1
@@ -356,7 +356,7 @@ describe Minitest::Spec do
   end
 
   it "needs to verify instances of a class" do
-    _(_(42).wont_be_instance_of(String)).must_equal false
+    _(_(42).wont_be_instance_of(String)).must_equal true
 
     assert_triggered "Expected 42 to not be a kind of #{Int.name}." do
       _(42).wont_be_kind_of Int
@@ -370,8 +370,8 @@ describe Minitest::Spec do
   it "needs to verify kinds of a class" do
     @assertion_count += 2
 
-    _(_(42).wont_be_kind_of(String)).must_equal false
-    _(_(proc {}).wont_be_kind_of(String)).must_equal false
+    _(_(42).wont_be_kind_of(String)).must_equal true
+    _(_(proc {}).wont_be_kind_of(String)).must_equal true
 
     assert_triggered "Expected 42 to not be a kind of #{Int.name}." do
       _(42).wont_be_kind_of Int
@@ -405,7 +405,7 @@ describe Minitest::Spec do
   it "needs to verify mismatch" do
     @assertion_count += 3 # match is 2
 
-    _(_("blah").wont_match(/\d+/)).must_equal false
+    _(_("blah").wont_match(/\d+/)).must_equal true
 
     assert_triggered "Expected /\\w+/ to not match \"blah\"." do
       _("blah").wont_match(/\w+/)
@@ -431,7 +431,7 @@ describe Minitest::Spec do
   it "needs to verify non-emptyness" do
     @assertion_count += 3 # empty is 2 assertions
 
-    _(_(["some item"]).wont_be_empty).must_equal false
+    _(_(["some item"]).wont_be_empty).must_equal true
 
     assert_triggered "Expected [] to not be empty." do
       _([]).wont_be_empty
@@ -443,7 +443,7 @@ describe Minitest::Spec do
   end
 
   it "needs to verify non-identity" do
-    _(_(1).wont_be_same_as(2)).must_equal false
+    _(_(1).wont_be_same_as(2)).must_equal true
 
     assert_triggered "Expected 1 (oid=N) to not be the same as 1 (oid=N)." do
       _(1).wont_be_same_as 1
@@ -455,7 +455,7 @@ describe Minitest::Spec do
   end
 
   it "needs to verify non-nil" do
-    _(_(42).wont_be_nil).must_equal false
+    _(_(42).wont_be_nil).must_equal true
 
     assert_triggered "Expected nil to not be nil." do
       _(nil).wont_be_nil
@@ -467,7 +467,7 @@ describe Minitest::Spec do
   end
 
   it "needs to verify objects not responding to a message" do
-    _(_("").wont_respond_to(:woot!)).must_equal false
+    _(_("").wont_respond_to(:woot!)).must_equal true
 
     assert_triggered "Expected \"\" to not respond to to_s." do
       _("").wont_respond_to :to_s
@@ -608,7 +608,7 @@ describe Minitest::Spec do
   it "needs to verify using any (negative) predicate" do
     @assertion_count -= 1 # doesn"t take a message
 
-    _(_("blah").wont_be(:empty?)).must_equal false
+    _(_("blah").wont_be(:empty?)).must_equal true
 
     assert_triggered "Expected \"\" to not be empty?." do
       _("").wont_be :empty?


### PR DESCRIPTION
Updates the `refute` method to make it match its lexical meaning. A
successful refutal will return `true` and a failed one will raise. Given
that refute is used by other assertion definitions, the following
methods now return `true` on successful evaluation:

- path_wont_exist
- wont_include
- wont_be
- wont_be_close_to
- wont_be_within_epsilon
- wont_equal
- wont_be_instance_of
- wont_be_kind_of
- wont_match
- wont_be_empty
- wont_be_same_as
- wont_be_nil
- wont_respond_to

Having it return `true` means that you could do something like

```ruby
assert(refute(thing.something?))
```

Although I'm not sure why one would do that