### PR TITLE
Add directory existence assertions

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -190,6 +190,14 @@ module Minitest
     end
 
     ##
+    # Fails unless +dir+ exists.
+
+    def assert_directory_exists dir, msg = nil
+      msg = message(msg) { "Expected '#{dir}' to be a directory" }
+      assert File.directory?(dir), msg
+    end
+
+    ##
     # Fails unless +obj+ is empty.
 
     def assert_empty obj, msg = nil
@@ -629,6 +637,14 @@ module Minitest
     def refute test, msg = nil
       msg ||= message { "Expected #{mu_pp(test)} to not be truthy" }
       assert !test, msg
+    end
+
+    ##
+    # Fails if +dir+ exists.
+
+    def refute_directory_exists dir, msg = nil
+      msg = message(msg) { "Expected '#{dir}' to not be a directory" }
+      refute File.directory?(dir), msg
     end
 
     ##


### PR DESCRIPTION
Hi!

So in https://github.com/seattlerb/minitest/pull/790 I added some path assertions because of a TODO comment I saw in rubygems.

Now I'm removing the assertions from rubygems since they've been added here, but I have the doubt whether the TODO comment was also meant to be applied to directory existance matchers.

The relevant code in rubygems is:

https://github.com/rubygems/rubygems/blob/05920f2f0cc4394636cf46fa352f86e5452f6b64/lib/rubygems/test_case.rb#L130-L141

If this was not the intention, I'm super happy to close this PR, just wanted to make sure.

If this was the intention, I'll add tests and whatever needed.