### PR TITLE
Bump Ruby version to include 3.1 (ruby-head)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Hoe.spec "minitest" do
 
   license "MIT"
 
-  require_ruby_version [">= 2.2", "< 3.1"]
+  require_ruby_version [">= 2.2", "< 3.2"]
 end
 
 desc "Find missing expectations"


### PR DESCRIPTION
3.0 was released, and ruby-head is now 3.1
See https://github.com/rspec/rspec-expectations/pull/1245/checks?check_run_id=1611861008

Fixes #861