### PR TITLE
Enable Ruby deprecation warnings by default

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -53,6 +53,10 @@ module Minitest
   # Registers Minitest to run at process exit
 
   def self.autorun
+    if Object.const_defined?(:Warning) && Warning.respond_to?(:[]=)
+      Warning[:deprecated] = true
+    end
+
     at_exit {
       next if $! and not ($!.kind_of? SystemExit and $!.success?)
 


### PR DESCRIPTION
Ruby 2.7.2 turned deprecation warnings off by default, and it is now recommended that test frameworks do enable them.

See https://bugs.ruby-lang.org/issues/17591 for more context.
 