### PR TITLE
Close then unlink tempfiles on Windows

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -562,15 +562,13 @@ module Minitest
 
           return captured_stdout.read, captured_stderr.read
         ensure
-          captured_stdout.unlink
-          captured_stderr.unlink
           $stdout.reopen orig_stdout
           $stderr.reopen orig_stderr
 
           orig_stdout.close
           orig_stderr.close
-          captured_stdout.close
-          captured_stderr.close
+          captured_stdout.close!
+          captured_stderr.close!
         end
       end
     end


### PR DESCRIPTION
In ruby/ruby test actions, number of "leaked tempfile" messages are shown on Windows.

As Windows disallows removing open files, `Tempfile#unlink` fails silently before `#close`.
Close then unlink by `#close!` instead.

https://github.com/rubygems/rubygems/pull/4681