### PR TITLE
Use assert_match instead of assert_equal to test the error message

### DIFF
--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -133,7 +133,7 @@ class TestMinitestMock < Minitest::Test
       @mock.expect :blah, 3, false
     end
 
-    assert_equal "args must be an array", e.message
+    assert_match "args must be an array", e.message
   end
 
   def test_respond_appropriately
@@ -150,7 +150,7 @@ class TestMinitestMock < Minitest::Test
 
     expected = "unmocked method :bar, expected one of [:foo, :meaning_of_life]"
 
-    assert_equal expected, e.message
+    assert_match expected, e.message
   end
 
   def test_assign_per_mock_return_values
@@ -309,7 +309,7 @@ class TestMinitestMock < Minitest::Test
 
     exp = "args ignored when block given"
 
-    assert_equal exp, e.message
+    assert_match exp, e.message
   end
 
   def test_mock_returns_retval_when_called_with_block
@@ -822,7 +822,7 @@ class TestMinitestStub < Minitest::Test
       end
     end
     exp = "undefined method `write' for nil:NilClass"
-    assert_equal exp, e.message
+    assert_match exp, e.message
   end
 
   def test_stub_value_block_args_6


### PR DESCRIPTION
Ruby 3.1 will enhance some kind of error messages by showing a code line
with a underline. See https://bugs.ruby-lang.org/issues/17930 in detail.

Minitest checks the error message by assert_equal, which leads to test
failures like this.

```
  2) Failure:
TestMinitestMock#test_no_method_error_on_unexpected_methods [/home/runner/work/ruby/ruby/src/gems/src/minitest/test/minitest/test_minitest_mock.rb:153]:
--- expected
+++ actual
@@ -1 +1,4 @@
-"unmocked method :bar, expected one of [:foo, :meaning_of_life]"
+"unmocked method :bar, expected one of [:foo, :meaning_of_life]
+
+          raise NoMethodError, \"unmocked method %p, expected one of %p\" %
+          ^^^^^"
```

This changeset makes the tests tolerant by using assert_match instead of
assert_equal.