### PR TITLE
Fix a typo in changes in 5.0.0

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -561,7 +561,7 @@ Minitest 5:
   * Added Minitest::Benchmark.
     * Your benchmarks need to move to their own subclass.
     * Benchmarks using the spec DSL have to have "Bench" somewhere in their describe.
-  * MiniTest::Unit.after_tests moved to Minitest.after_tests
+  * MiniTest::Unit.after_tests moved to Minitest.after_run
   * MiniTest::Unit.autorun is now Minitest.autorun. Just require minitest/autorun pls.
   * Removed ParallelEach#grep since it isn't used anywhere.
   * Renamed Runnable#__name__ to Runnable#name (but uses @NAME internally).


### PR DESCRIPTION
Fix a typo in changes in 5.0.0 9a57c520ceac76abfe6105866f8548a94eb357b6 (change = 8451).

Instead of `Minitest.after_tests`, `Minitest.after_run` was introduced in e824f68f2cd493d2e51ec385add2c6ff55a61a35 (change = 8467).

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>