### PR TITLE
Use Etc.nprocessors by default in order to maximize cpu usage.

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -3,6 +3,7 @@ require "thread"
 require "mutex_m"
 require "minitest/parallel"
 require "stringio"
+require "etc"
 
 ##
 # :include: README.rdoc
@@ -23,7 +24,7 @@ module Minitest
   mc.send :attr_accessor, :parallel_executor
 
   warn "DEPRECATED: use MT_CPU instead of N for parallel test runs" if ENV["N"]
-  n_threads = (ENV["MT_CPU"] || ENV["N"] || 2).to_i
+  n_threads = (ENV["MT_CPU"] || ENV["N"] || Etc.nprocessors).to_i
   self.parallel_executor = Parallel::Executor.new n_threads
 
   ##


### PR DESCRIPTION
2 threads by default is too few in 2021. A more modern way is to detect the number of CPU cores automatically.