### PR TITLE
Don't pass implicit blocks for method_missing stubs

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -217,9 +217,11 @@ class Object
     metaclass = class << self; self; end
 
     if respond_to? name and not methods.map(&:to_s).include? name.to_s then
-      metaclass.send :define_method, name do |*args|
-        super(*args)
-      end
+      metaclass.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{name}(*args) # def name(*args)
+          super(*args)     #   super(*args)
+        end                # end
+      CODE
     end
 
     metaclass.send :alias_method, new_name, name

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -492,6 +492,32 @@ class TestMinitestStub < Minitest::Test
     @tc.assert_equal false, dynamic.found
   end
 
+  def test_dynamic_method_does_not_keep_implicit_block
+    @assertion_count = 4
+
+    dynamic = Class.new do
+      def self.respond_to? meth
+        meth == :given_a_block?
+      end
+
+      def self.method_missing meth, *args, &block
+        if meth == :given_a_block?
+          block_given?
+        else
+          super
+        end
+      end
+    end
+
+    @tc.refute dynamic.given_a_block?
+    @tc.assert dynamic.given_a_block? {}
+
+    dynamic.stub(:given_a_block?, :_unused) {}
+
+    @tc.refute dynamic.given_a_block?
+    @tc.assert dynamic.given_a_block? {}
+  end
+
   def test_stub_NameError
     e = @tc.assert_raises NameError do
       Time.stub :nope_nope_nope, 42 do


### PR DESCRIPTION
Switch from `send :define_method` to `class_eval` for stubbed methods
that would otherwise by handled by `method_missing`

With the previous implementation, the block passed to `stub` is in
scope during `define_method`, which means that once a method on an
object has been stubbed, subsequent method calls will always receive
that implicit block.

I've added a new test that presents this behavior with the existing
implementation, and works properly with this change.