### PR TITLE
Add GitHub Actions CI, small platform lib & test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    name: >-
+      test-${{ matrix.os }} ${{ matrix.ruby }}
+    env:
+      TESTOPTS: -v
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, windows-2022 ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
+        include:
+          - { os: windows-2022, ruby: mingw }
+          - { os: windows-2022, ruby: ucrt  }
+
+        exclude:
+          - { os: windows-2022, ruby: head  }
+          - { os: macos-10.15 , ruby: 2.6   }
+          - { os: macos-10.15 , ruby: 2.7   }
+          - { os: macos-10.15 , ruby: '3.0' }
+          - { os: macos-10.15 , ruby: head  }
+          - { os: macos-11    , ruby: 2.2   }
+          - { os: macos-11    , ruby: 2.3   }
+          - { os: macos-11    , ruby: 2.4   }
+          - { os: macos-11    , ruby: 2.5   }
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby
+        uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: install hoe
+        run:  gem install hoe
+
+      - name: rake test
+        run:  |
+          rake test
+          ruby -v
+        timeout-minutes: 3
+
+  isolated:
+    name: >-
+      isolated-${{ matrix.os }} ${{ matrix.ruby }}
+    env:
+      TESTOPTS: -v
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, windows-2022 ]
+        ruby: [ 2.3, '3.0' ]
+        include:
+          - { os: macos-10.15 , ruby: 2.3   }
+          - { os: macos-11    , ruby: '3.0' }
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby
+        uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: install hoe
+        run:  gem install hoe
+
+      - name: rake test:isolated
+        run:  |
+          rake test:isolated
+          ruby -v
+        timeout-minutes: 3

--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -792,7 +792,7 @@ module Minitest
 
     def skip_until y,m,d,msg
       skip msg if Time.now < Time.local(y, m, d)
-      where = caller.first.split(/:/, 3).first(2).join ":"
+      where = caller.first.rpartition(':in').reject(&:empty?).first
       warn "Stale skip_until %p at %s" % [msg, where]
     end
 

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -28,6 +28,9 @@ class TestMinitestAssertions < Minitest::Test
 
   RUBY18 = !defined? Encoding
 
+  # not included in JRuby
+  RE_LEVELS = /\(\d+ levels\) /
+
   class DummyTest
     include Minitest::Assertions
     # include Minitest::Reportable # TODO: why do I really need this?
@@ -756,12 +759,12 @@ class TestMinitestAssertions < Minitest::Test
       Class: <SomeError>
       Message: <\"blah\">
       ---Backtrace---
-      FILE:LINE:in \`test_assert_raises_default_triggered\'
+      FILE:LINE:in \`block in test_assert_raises_default_triggered\'
       ---------------
     EOM
 
     actual = e.message.gsub(/^.+:\d+/, "FILE:LINE")
-    actual.gsub!(/block \(\d+ levels\) in /, "") if RUBY_VERSION >= "1.9.0"
+    actual.gsub!(RE_LEVELS, "") unless jruby?
 
     assert_equal expected, actual
   end
@@ -835,12 +838,12 @@ class TestMinitestAssertions < Minitest::Test
       Class: <AnError>
       Message: <\"some message\">
       ---Backtrace---
-      FILE:LINE:in \`test_assert_raises_subclass_triggered\'
+      FILE:LINE:in \`block in test_assert_raises_subclass_triggered\'
       ---------------
     EOM
 
     actual = e.message.gsub(/^.+:\d+/, "FILE:LINE")
-    actual.gsub!(/block \(\d+ levels\) in /, "") if RUBY_VERSION >= "1.9.0"
+    actual.gsub!(RE_LEVELS, "") unless jruby?
 
     assert_equal expected.chomp, actual
   end
@@ -857,12 +860,12 @@ class TestMinitestAssertions < Minitest::Test
       Class: <SyntaxError>
       Message: <\"icky\">
       ---Backtrace---
-      FILE:LINE:in \`test_assert_raises_triggered_different\'
+      FILE:LINE:in \`block in test_assert_raises_triggered_different\'
       ---------------
     EOM
 
     actual = e.message.gsub(/^.+:\d+/, "FILE:LINE")
-    actual.gsub!(/block \(\d+ levels\) in /, "") if RUBY_VERSION >= "1.9.0"
+    actual.gsub!(RE_LEVELS, "") unless jruby?
 
     assert_equal expected, actual
   end
@@ -880,12 +883,12 @@ class TestMinitestAssertions < Minitest::Test
       Class: <SyntaxError>
       Message: <\"icky\">
       ---Backtrace---
-      FILE:LINE:in \`test_assert_raises_triggered_different_msg\'
+      FILE:LINE:in \`block in test_assert_raises_triggered_different_msg\'
       ---------------
     EOM
 
     actual = e.message.gsub(/^.+:\d+/, "FILE:LINE")
-    actual.gsub!(/block \(\d+ levels\) in /, "") if RUBY_VERSION >= "1.9.0"
+    actual.gsub!(RE_LEVELS, "") unless jruby?
 
     assert_equal expected.chomp, actual
   end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -499,7 +499,8 @@ class TestMinitestStub < Minitest::Test
       end
     end
 
-    exp = /undefined method `nope_nope_nope' for( class)? `#{self.class}::Time'/
+    exp = jruby? ? /Undefined method nope_nope_nope for '#{self.class}::Time'/ :
+      /undefined method `nope_nope_nope' for( class)? `#{self.class}::Time'/
     assert_match exp, e.message
   end
 

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -13,6 +13,10 @@ class TestMinitestReporter < MetaMetaMetaTestCase
   attr_accessor :r, :io
 
   def new_composite_reporter
+    # Ruby bug in older versions of 2.2 & 2.3 on all platforms
+    # Latest Windows builds were 2.2.6 and 2.3.3.  Latest Ruby releases were
+    # 2.2.10 and 2.3.8.
+    skip if windows? && RUBY_VERSION < '2.4'
     reporter = Minitest::CompositeReporter.new
     reporter << Minitest::SummaryReporter.new(self.io)
     reporter << Minitest::ProgressReporter.new(self.io)

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -848,19 +848,25 @@ class TestMinitestUnitTestCase < Minitest::Test
     $VERBOSE = orig_verbose
   end
 
+  def sample_test_case(rand)
+    srand rand
+    Class.new FakeNamedTest do
+      100.times do |i|
+        define_method("test_#{i}") { assert true }
+      end
+    end.runnable_methods
+  end
+
+  # srand varies with OS
   def test_runnable_methods_random
     @assertion_count = 0
 
-    sample_test_case = Class.new FakeNamedTest do
-      def self.test_order; :random; end
-      def test_test1; assert "does not matter" end
-      def test_test2; assert "does not matter" end
-      def test_test3; assert "does not matter" end
-    end
+    random_tests_1 = sample_test_case 42
+    random_tests_2 = sample_test_case 42
+    random_tests_3 = sample_test_case 1_000
 
-    srand 42
-    expected = %w[test_test2 test_test1 test_test3]
-    assert_equal expected, sample_test_case.runnable_methods
+    assert_equal random_tests_1, random_tests_2
+    refute_equal random_tests_1, random_tests_3
   end
 
   def test_runnable_methods_sorted


### PR DESCRIPTION
GitHub Actions (GHA) has limits to concurrent jobs. The macOS limit is 5 for Free/Pro/Team accounts, and the combined Ubuntu/Windows limit is 20 for Free accounts. So, tried to select the jobs to run based on that. CI often completes in ~ 2 minutes.

Tried to add JRuby and TruffleRuby, both seem to have intermittent issues. Hopefully I can do some more work with it. Many other CI systems have a similar 'allow-failure' syntax for jobs. Actions does not. We could add another workflow for JRuby and TruffleRuby that won't fail the commit/PR, but would log failures/errors so someone can fix the issues?

I added TESTOPTS=-v, which can be removed.

Misc Notes

The standard 'action' to load Ruby is `ruby/setup-ruby`.  Currently, it is not running the current Windows Image, it also cannot work with Windows 'UCRT' builds. 'UCRT' is a new gcc based tool chain that will be the chain used when Windows Ruby 3.1 is released.  So, for the time being, `MSP-Greg/ruby-setup-ruby@win-ucrt-1` is being used, which wraps `ruby/setup-ruby`.   

Secondly, in the past, some other CI systems' Ruby trunk/head builds were just cron jobs that built Ruby, but did not run any of its test suites.  All of the trunk/head builds available with GHA are fully tested and used extensively.  JFYI, if a cron trunk/head build does not pass the test suites, it does not replace the previous passing build.

Finally, in the past, repos without Actions CI will not run the CI when it's added in a PR. We'll see what happens with this... You can look at a run in my fork: https://github.com/MSP-Greg/minitest/actions/runs/1542633084

Closes #683