### PR TITLE
Prevent random test failure because of parallel execution

### DIFF
--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -48,9 +48,11 @@ class TestMinitestUnit < MetaMetaMetaTestCase
           "test/test_autotest.rb:62:in `test_add_exception'"]
     ex = util_expand_bt ex
 
-    fu = Minitest.filter_backtrace(bt)
+    Minitest::Test.io_lock.synchronize do # try not to trounce in parallel
+      fu = Minitest.filter_backtrace(bt)
 
-    assert_equal ex, fu
+      assert_equal ex, fu
+    end
   end
 
   def test_filter_backtrace_all_unit
@@ -71,8 +73,10 @@ class TestMinitestUnit < MetaMetaMetaTestCase
     bt = util_expand_bt bt
 
     ex = ["-e:1"]
-    fu = Minitest.filter_backtrace bt
-    assert_equal ex, fu
+    Minitest::Test.io_lock.synchronize do # try not to trounce in parallel
+      fu = Minitest.filter_backtrace bt
+      assert_equal ex, fu
+    end
   end
 
   def test_filter_backtrace__empty
@@ -112,7 +116,9 @@ class TestMinitestUnit < MetaMetaMetaTestCase
       2 runs, 1 assertions, 1 failures, 1 errors, 0 skips
     EOM
 
-    assert_report expected
+    Minitest::Test.io_lock.synchronize do # try not to trounce in parallel
+      assert_report expected
+    end
   end
 
   def test_passed_eh_teardown_good


### PR DESCRIPTION
Some tests of minitest randomly fail like this.

```
    1) Failure:
  TestMinitestUnit#test_filter_backtrace_unit_starts [/home/runner/work/ruby/ruby/src/gems/src/minitest/test/minitest/test_minitest_test.rb:75]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -["-e:1"]
  +["/home/runner/work/ruby/ruby/src/gems/src/minitest/lib/minitest/mini/test.rb:165:in `__send__'", "/home/runner/work/ruby/ruby/src/gems/src/minitest/lib/minitest/mini/test.rb:161:in `each'", "/home/runner/work/ruby/ruby/src/gems/src/minitest/lib/minitest/mini/test.rb:158:in `each'", "/home/runner/work/ruby/ruby/src/gems/src/minitest/lib/minitest/mini/test.rb:139:in `run'", "/home/runner/work/ruby/ruby/src/gems/src/minitest/lib/minitest/mini/test.rb:106:in `run'", "/home/runner/work/ruby/ruby/src/gems/src/minitest/lib/minitest/mini/mini/test.rb:29", "-e:1"]
```
https://github.com/ruby/ruby/runs/4696460222?check_suite_focus=true

This is because Minitest::Test#with_empty_backtrace_filter modifies
`Minitest.backtrace_filter` temporarily. The setting is process-global,
not thread-local. So, if another test that depends on the setting is
executed in parallel when the setting is changed, it fails.

This change prevents the random failure by guarding the test that
depends on `Minitest.backtrace_filter`.