### PR TITLE
Fixing an issue with a spoiling of the object singleton classes

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -216,7 +216,9 @@ class Object
 
     metaclass = class << self; self; end
 
-    if respond_to? name and not methods.map(&:to_s).include? name.to_s then
+    if respond_to?( name ) && !methods.map(&:to_s).include?( name.to_s )
+      # this mean that 'name' is a public method which is expected
+      # to be defined dynamically somewhere inside ancestors chain
       metaclass.send :define_method, name do |*args|
         super(*args)
       end
@@ -237,8 +239,7 @@ class Object
 
     yield self
   ensure
-    metaclass.send :undef_method, name
-    metaclass.send :alias_method, name, new_name
-    metaclass.send :undef_method, new_name
+    metaclass.send :remove_method, name
+    metaclass.send :remove_method, new_name
   end
 end

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -213,10 +213,11 @@ class Object
 
   def stub name, val_or_callable, *block_args
     new_name = "__minitest_stub__#{name}"
+    singleton_has_stubbing_method = singleton_methods.map(&:to_s).include?( name.to_s )
 
     metaclass = class << self; self; end
 
-    if respond_to?( name ) && !methods.map(&:to_s).include?( name.to_s )
+    if respond_to? name and not methods.map(&:to_s).include? name.to_s then
       # this mean that 'name' is a public method which is expected
       # to be defined dynamically somewhere inside ancestors chain
       metaclass.send :define_method, name do |*args|
@@ -240,6 +241,7 @@ class Object
     yield self
   ensure
     metaclass.send :remove_method, name
+    metaclass.send :alias_method, name, new_name if singleton_has_stubbing_method
     metaclass.send :remove_method, new_name
   end
 end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -521,6 +521,44 @@ class TestMinitestStub < Minitest::Test
 
   alias test_stub_value__old test_stub_value # TODO: remove/rename
 
+  def test_instance_singleton_class_is_not_dirty
+    _class = Class.new do
+      def clean; :dirty end
+    end
+
+    _module = Module.new do
+      def clean; :clean end
+    end
+
+    shirt, t_shirt = _class.new, _class.new
+
+    shirt.stub(:clean, :clean) do |s|
+      assert_equal( s.clean, :clean )
+    end
+
+    _class.prepend(_module)
+
+    assert_equal( t_shirt.clean, :clean )
+    assert_equal( shirt.clean, :clean )
+  end
+
+  def test_class_singleton_class_is_not_dirty
+    _class = Class.new do
+      def self.clean; :dirty end
+    end
+
+    _module = Module.new do
+      def clean; :clean end
+    end
+
+    _class.stub(:clean, :clean) do |s|
+      assert_equal( s.clean, :clean )
+    end
+
+    _class.extend(_module)
+
+    assert_equal( _class.clean, :clean )
+  end
   ## Permutation Sets:
 
   # [:value, :lambda]

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -532,6 +532,9 @@ class TestMinitestStub < Minitest::Test
 
     shirt, t_shirt = _class.new, _class.new
 
+    assert_equal( t_shirt.clean, :dirty )
+    assert_equal( shirt.clean, :dirty )
+
     shirt.stub(:clean, :clean) do |s|
       assert_equal( s.clean, :clean )
     end
@@ -542,22 +545,17 @@ class TestMinitestStub < Minitest::Test
     assert_equal( shirt.clean, :clean )
   end
 
-  def test_class_singleton_class_is_not_dirty
+  def test_class_singleton_class_will_not_loose_its_method
     _class = Class.new do
       def self.clean; :dirty end
     end
 
-    _module = Module.new do
-      def clean; :clean end
-    end
 
     _class.stub(:clean, :clean) do |s|
       assert_equal( s.clean, :clean )
     end
-
-    _class.extend(_module)
-
-    assert_equal( _class.clean, :clean )
+    # method is still present and unchanged
+    assert_equal( _class.clean, :dirty )
   end
   ## Permutation Sets:
 

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -550,7 +550,6 @@ class TestMinitestStub < Minitest::Test
       def self.clean; :dirty end
     end
 
-
     _class.stub(:clean, :clean) do |s|
       assert_equal( s.clean, :clean )
     end


### PR DESCRIPTION
.stub method defined in minitest/mock executing an alias_method against singleton_class under the hood.  
Running an alias_method over a singleton_class without running a 'remove_method' later will keep singleton_class 'dirty' and running undef_method might clear more than needed.  

Usually this will not lead to any consequences, but if you are stubbing methods of a global objects and trying to enrich functionality of their ancestors chain 'after' the the first stubbing is done, then you might fall into trouble.

Even though the probability for such a case is tiny, it's not 0 and singleton class should be kept clean. 